### PR TITLE
feat: eliminate Flask reloader port confusion with run.sh script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Auto Port Detection (Recommended)
 ```bash
-python main.py
+./run.sh
 ```
 - Automatically finds the first free port starting from 5000
 - Displays the URL Claude should use: `http://127.0.0.1:{port}`
@@ -12,7 +12,7 @@ python main.py
 
 ### Manual Port Selection
 ```bash
-python main.py --port 5002
+python3 main.py --port 5002
 ```
 - Use when you need a specific port
 - If port is busy, will show helpful error message
@@ -20,7 +20,7 @@ python main.py --port 5002
 ## For Claude Code
 
 When starting the CRM application:
-1. Run `python main.py` (no arguments needed)
+1. Run `./run.sh` (recommended - auto-detects port)
 2. Look for the output: `🚀 Starting CRM application on http://127.0.0.1:{port}`
 3. Use that URL to access the application
 
@@ -37,16 +37,16 @@ When starting the CRM application:
 Each worktree can run simultaneously:
 ```bash
 # Worktree 1
-python main.py  # Uses port 5000
+./run.sh  # Uses port 5000
 
 # Worktree 2  
-python main.py  # Uses port 5001 (auto-detected)
+./run.sh  # Uses port 5001 (auto-detected)
 
 # Worktree 3
-python main.py  # Uses port 5002 (auto-detected)
+./run.sh  # Uses port 5002 (auto-detected)
 ```
 
 ### Testing Specific Ports
 ```bash
-python main.py --port 8080  # Force specific port
+python3 main.py --port 8080  # Force specific port
 ```

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import argparse
-import socket
 from pathlib import Path
 from flask import Flask
 from app.models import db
@@ -73,39 +72,20 @@ def create_app():
     return app
 
 
-def find_free_port(start_port=5000, max_attempts=10):
-    """Find a free port starting from start_port."""
-    for port in range(start_port, start_port + max_attempts):
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(('localhost', port))
-                return port
-        except OSError:
-            continue
-    raise RuntimeError(f"No free port found in range {start_port}-{start_port + max_attempts - 1}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run the CRM Flask application')
-    parser.add_argument('--port', type=int, help='Port number to run the application on (auto-detects if not specified)')
+    parser.add_argument('--port', type=int, required=True, help='Port number to run the application on')
     args = parser.parse_args()
     
     app = create_app()
     
-    if args.port:
-        # Use specified port
-        port = args.port
-        try:
-            app.run(debug=True, port=port)
-        except OSError as e:
-            if "Address already in use" in str(e):
-                print(f"\n❌ Error: Port {port} is already in use!")
-                print(f"💡 Try running without --port to auto-detect a free port")
-            else:
-                raise
-    else:
-        # Auto-detect free port
-        port = find_free_port()
-        print(f"🚀 Starting CRM application on http://127.0.0.1:{port}")
-        print(f"📝 Claude Code: Use this URL to access the application")
-        app.run(debug=True, port=port)
+    try:
+        app.run(debug=True, port=args.port)
+    except OSError as e:
+        if "Address already in use" in str(e):
+            print(f"\n❌ Error: Port {args.port} is already in use!")
+            print(f"💡 Use ./run.sh to auto-detect a free port")
+        else:
+            raise

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Find the first available port starting from 5000
+find_free_port() {
+    local start_port=5000
+    local max_attempts=10
+    
+    for ((port=start_port; port<start_port+max_attempts; port++)); do
+        if ! nc -z localhost $port 2>/dev/null; then
+            echo $port
+            return 0
+        fi
+    done
+    
+    echo "Error: No free port found in range $start_port-$((start_port+max_attempts-1))" >&2
+    exit 1
+}
+
+# Get free port
+PORT=$(find_free_port)
+
+echo "🚀 Starting CRM application on http://127.0.0.1:$PORT"
+echo "📝 Claude Code: Use this URL to access the application"
+
+# Start the Flask application
+python3 main.py --port $PORT


### PR DESCRIPTION
## Summary
- Creates `run.sh` script to handle port detection externally 
- Eliminates confusing duplicate startup messages from Flask's debug reloader
- Simplifies `main.py` by removing auto-detection logic
- Updates documentation to recommend `./run.sh` as primary startup method

## Test plan
- [x] Test `./run.sh` shows single clean startup message
- [x] Test multiple worktrees can run simultaneously with different ports
- [x] Test `python3 main.py --port 5002` still works for manual port selection
- [x] Verify no more "5000 and 5001" confusion in output