### PR TITLE
fix: resolve Multi Task JSON serialization and ensure contacts improvements compatibility

### DIFF
--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -157,11 +157,16 @@ def new_multi():
         db.session.commit()
         return jsonify({'status': 'success', 'task_id': parent_task.id})
     
+    # Convert objects to dictionaries for JSON serialization in template
+    companies_dict = [{'id': c.id, 'name': c.name} for c in companies]
+    contacts_dict = [{'id': c.id, 'name': c.name, 'company_id': c.company_id} for c in contacts]
+    opportunities_dict = [{'id': o.id, 'name': o.name, 'company_id': o.company_id} for o in opportunities]
+    
     return render_template('tasks/multi_new.html', 
                          form=form,
-                         companies=companies, 
-                         contacts=contacts, 
-                         opportunities=opportunities)
+                         companies=companies_dict, 
+                         contacts=contacts_dict, 
+                         opportunities=opportunities_dict)
 
 
 @tasks_bp.route('/parent-tasks', methods=['GET'])


### PR DESCRIPTION
## Summary
- Fixes JSON serialization issue in Multi Task creation page
- Ensures compatibility between contacts page improvements and Multi Task functionality
- Successfully rebased on main with all features preserved

## Changes
- **JSON Serialization Fix**: Convert Company, Contact, and Opportunity objects to dictionaries for proper template serialization
- **Contacts Improvements Preserved**: All DRY principles and UI enhancements from contacts branch maintained
- **Multi Task Integration**: Full parent/child task functionality working seamlessly

## Test Plan
- [x] Multi Task creation page loads without errors
- [x] Contacts page improvements still functional
- [x] Task hierarchy and parent/child relationships working
- [x] All existing functionality preserved
- [x] Application runs successfully on http://127.0.0.1:5001

## Technical Details
- Resolved `TypeError: Object of type Company is not JSON serializable`
- Maintains backward compatibility with existing task functionality
- Clean rebase from main with no conflicts