### PR TITLE
Fix run.sh hanging on free ports

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ find_free_port() {
     local max_attempts=10
     
     for ((port=start_port; port<start_port+max_attempts; port++)); do
-        if ! nc -z localhost $port 2>/dev/null; then
+        if ! timeout 1 nc -z localhost $port 2>/dev/null; then
             echo $port
             return 0
         fi


### PR DESCRIPTION
## Summary
- Fixed run.sh script hanging when checking for free ports
- Added timeout to nc command to prevent indefinite hanging

## Test plan
- [x] Script now properly detects free ports without hanging
- [x] Tested port scanning functionality
- [x] Verified Flask application starts correctly