### PR TITLE
feat: improve tasks page layout with vertical centering and content alignment

### DIFF
--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -510,8 +510,28 @@
     margin-bottom: 0.75rem; /* mb-3 */
     cursor: pointer;
     transition: box-shadow 0.15s ease-in-out; /* transition-shadow */
+    min-height: 120px; /* Consistent minimum height */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 
 .task-card:hover {
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); /* hover:shadow-md */
+}
+
+/* Task summary vertical centering */
+.task-summary-centered {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 80px;
+}
+
+/* Improved task card balance */
+.task-card-balanced {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 120px;
 }

--- a/app/templates/components/page_template.html
+++ b/app/templates/components/page_template.html
@@ -36,9 +36,9 @@
 {% if summary_data %}
 <div class="mb-8 card-padded-lg">
     <h2 class="text-section-title mb-4">{{ summary_data.title }}</h2>
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 items-center min-h-[80px]">
         {% for stat in summary_data.stats %}
-        <div class="text-center">
+        <div class="text-center flex flex-col justify-center">
             <div class="text-2xl font-bold {{ stat.color_class or 'text-gray-900' }}">
                 {{ stat.value }}
             </div>

--- a/app/templates/components/task_card.html
+++ b/app/templates/components/task_card.html
@@ -139,9 +139,9 @@
      :class="{ 'ring-2 ring-blue-200 bg-blue-50': isEditing }">
     
     <!-- Task description with badges and reschedule buttons -->
-    <div class="flex items-center justify-between mb-3">
+    <div class="flex items-center justify-between mb-3 min-h-[48px]">
         <div class="flex items-center space-x-2 flex-grow">
-            <div class="flex flex-col items-center space-y-1">
+            <div class="flex flex-col items-end space-y-1 text-right min-w-[80px]">
                 {% set priority_color = 'red' if task.priority == 'high' else
                                       'yellow' if task.priority == 'medium' else
                                       'green' %}
@@ -150,7 +150,7 @@
                     <span class="text-badge-tag">{{ task.next_step_type }}</span>
                 {% endif %}
             </div>
-            <div class="flex-grow">
+            <div class="flex-grow text-left">
                 {% if task.entity_name %}
                     <div class="flex items-center space-x-3">
                         <p class="text-label-primary">{{ task.entity_name }}</p>
@@ -165,7 +165,7 @@
                     <p class="text-label-primary">{{ task.description }}</p>
                 {% endif %}
             </div>
-            <div class="flex items-center space-x-2 flex-shrink-0">
+            <div class="flex items-center space-x-2 flex-shrink-0 text-left">
                 <!-- Task type badge (child tasks only) -->
                 {% if task.task_type == 'child' %}
                     <span class="badge-standard badge-green">{{ task.task_type_badge }}</span>
@@ -233,12 +233,12 @@
 
     <!-- Progress bar for parent tasks -->
     {% if task.task_type == 'parent' %}
-    <div class="flex items-center space-x-4 text-secondary mb-3">
-        <div class="flex items-center space-x-2">
+    <div class="flex items-center justify-between text-secondary mb-3 min-h-[32px]">
+        <div class="flex items-center space-x-2 text-right">
             <span class="badge-standard badge-blue">{{ task.task_type_badge }}</span>
             <span class="font-medium">Tasks: {{ task.child_tasks | selectattr('status', 'equalto', 'complete') | list | length }}/{{ task.child_tasks | length }}</span>
         </div>
-        <div class="flex items-center space-x-2">
+        <div class="flex items-center space-x-2 text-left">
             <div class="w-16 bg-gray-200 rounded-full h-2">
                 <div class="bg-blue-600 h-2 rounded-full" style="width: {{ task.completion_percentage }}%"></div>
             </div>


### PR DESCRIPTION
## Summary
- Implemented vertical centering for all three main row types on the tasks page
- Reversed content alignment within task cards as requested: priority badges now right-aligned, entity names and descriptions now left-aligned
- Added consistent minimum heights for better visual balance

## Changes Made
- **Task Summary Section**: Added `items-center` and `min-h-[80px]` for vertical centering of metrics
- **Task Cards**: Reversed alignment - priority badges/next step types right-aligned, entity names/descriptions left-aligned
- **CSS Enhancements**: Added minimum heights and flexbox centering for consistent task card appearance

## Test Plan
- [x] Verified task summary metrics are vertically centered
- [x] Confirmed task card content alignment is reversed as requested  
- [x] Tested all three row types display with proper vertical centering
- [x] Checked both parent and child task layouts maintain proper alignment