### PR TITLE
fix: eliminate dropdown double-loading flash

### DIFF
--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -354,8 +354,9 @@
 .multiselect-dropdown {
     position: absolute;
     top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    right: 0;
+    margin: 0 auto;
     z-index: 50;
     background-color: white;
     border: 1px solid #d1d5db;


### PR DESCRIPTION
## Summary
- Fixed dropdown positioning issue causing visual flash where dropdowns appear first on right, then center
- Replaced two-step CSS positioning with immediate centering for smooth UX

## Technical Details
- **Problem**: CSS `left: 50%; transform: translateX(-50%)` caused two-step render
- **Solution**: Use `left: 0; right: 0; margin: 0 auto` for immediate centering
- **Files**: `app/static/css/components.css` - `.multiselect-dropdown` class

## Test Plan
- [ ] Load any page with dropdowns (contacts, tasks, opportunities)
- [ ] Click dropdown buttons and verify they center immediately without flash
- [ ] Verify dropdown positioning remains visually identical
- [ ] Test on different screen sizes