### PR TITLE
Fix modal formatting consistency - DRY solution

### DIFF
--- a/app/templates/companies/new.html
+++ b/app/templates/companies/new.html
@@ -1,0 +1,26 @@
+{% extends "base/layout.html" %}
+
+{% block title %}New Company{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+    <div class="px-4 py-6 sm:px-0">
+        <h1 class="text-2xl font-bold text-gray-900 mb-6">Create New Company</h1>
+        
+        <div class="bg-white shadow rounded-lg p-6">
+            <p class="text-gray-600 mb-4">Use the "New Company" button above to create a new company.</p>
+            <button onclick="window.dispatchEvent(new CustomEvent('open-new-company-modal'))" 
+                    class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                <svg class="-ml-1 mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                </svg>
+                New Company
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block modals %}
+{% include "components/modals/company/company_new.html" %}
+{% endblock %}

--- a/app/templates/components/modals/base/generic_detail.html
+++ b/app/templates/components/modals/base/generic_detail.html
@@ -33,7 +33,7 @@
             <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
         </div>
         
-        <div x-show="!loading && {{ entity_type }}" class="space-y-4">
+        <div x-show="!loading && {{ entity_type }}" class="modal-body modal-content-spacing">
             {% if config.tabs %}
             <!-- Tab Navigation -->
             <div class="border-b border-gray-200">

--- a/app/templates/components/modals/base/generic_detail.html
+++ b/app/templates/components/modals/base/generic_detail.html
@@ -5,7 +5,6 @@
 <div x-data="{
         ...createCRUDMixin('{{ entity_type }}', {}, {}),
         ...createNotesMixin('{{ entity_type }}'),
-        mode: 'view', // 'new', 'view', 'edit'
         
         {% if config.tabs %}
         activeTab: '{{ config.tabs[0].key }}',
@@ -16,52 +15,19 @@
         {% endif %}
         
         async load{{ entity_type|title }}(id) {
-            this.mode = 'view';
             await this.loadEntity(id);
             this.openModal();
         },
         
-        openNew{{ entity_type|title }}() {
-            this.mode = 'new';
-            this.{{ entity_type }} = { ...{{ config.default_values|tojson }} };
-            this.openModal();
-        },
-        
-        enableEdit() {
-            this.mode = 'edit';
-        },
-        
         async save{{ entity_type|title }}Details() {
-            if (this.mode === 'new') {
-                return await this.createEntity();
-            } else {
-                return await this.saveEntity();
-            }
-        },
-        
-        get modalTitle() {
-            if (this.mode === 'new') return 'Create New {{ config.title_singular or entity_type|title }}';
-            if (this.mode === 'edit') return 'Edit {{ config.title_singular or entity_type|title }}';
-            return '{{ config.title }}';
-        },
-        
-        get isReadonly() {
-            return this.mode === 'view';
+            return await this.saveEntity();
         }
      }" 
      @open-detail-{{ entity_type }}-modal.window="load{{ entity_type|title }}($event.detail.id)"
-     @open-new-{{ entity_type }}-modal.window="openNew{{ entity_type|title }}()"
      @close-modal.window="closeModal()">
 
     {% call base_modal(entity_type + '-detail-modal', backdrop_click_close=false) %}
-        <div class="modal-header">
-            <h3 class="modal-title" id="modal-title" x-text="modalTitle"></h3>
-            <button @click="show = false" class="modal-close-button">
-                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
-        </div>
+        {{ modal_header(config.title) }}
         
         <div x-show="loading" class="text-center py-8">
             <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
@@ -108,44 +74,7 @@
             {% endif %}
         </div>
         
-        <div class="modal-footer">
-            <button @click="show = false" class="modal-cancel-button">
-                Cancel
-            </button>
-            <template x-if="mode === 'view'">
-                <button @click="enableEdit()" class="modal-save-button">
-                    Edit
-                </button>
-            </template>
-            <template x-if="mode === 'edit'">
-                <button @click="save{{ entity_type|title }}Details()"
-                        :disabled="saving"
-                        class="modal-save-button">
-                    <span x-show="!saving">Save Changes</span>
-                    <span x-show="saving" class="flex items-center">
-                        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                        Saving...
-                    </span>
-                </button>
-            </template>
-            <template x-if="mode === 'new'">
-                <button @click="save{{ entity_type|title }}Details()"
-                        :disabled="saving"
-                        class="modal-save-button">
-                    <span x-show="!saving">Create {{ config.title_singular or entity_type|title }}</span>
-                    <span x-show="saving" class="flex items-center">
-                        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                        Creating...
-                    </span>
-                </button>
-            </template>
-        </div>
+        {{ modal_footer(save_action="save" + entity_type|title + "Details()", save_text="Save Changes") }}
     {% endcall %}
 </div>
 {% endmacro %}
@@ -156,24 +85,21 @@
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <input type="text" x-model="{{ entity_type }}.{{ field.name }}" 
-                       :readonly="isReadonly"
-                       :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'"
+                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                        placeholder="{{ field.placeholder | default('') }}">
             </div>
         {% elif field.type == 'textarea' %}
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <textarea x-model="{{ entity_type }}.{{ field.name }}" 
-                          :readonly="isReadonly"
-                          :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'"
+                          class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                           rows="{{ field.rows | default(3) }}"></textarea>
             </div>
         {% elif field.type == 'select' %}
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <select x-model="{{ entity_type }}.{{ field.name }}" 
-                        :disabled="isReadonly"
-                        :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'">
+                        class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                     {% for option in field.options %}
                     <option value="{{ option.value if option is mapping else option }}">
                         {{ option.label if option is mapping else option|title }}
@@ -185,8 +111,7 @@
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <input type="date" x-model="{{ entity_type }}.{{ field.name }}" 
-                       :readonly="isReadonly"
-                       :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'">
+                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
             </div>
         {% elif field.type == 'grid' %}
             <div class="grid grid-cols-{{ field.columns | default(2) }} gap-4">

--- a/app/templates/components/modals/base/generic_detail.html
+++ b/app/templates/components/modals/base/generic_detail.html
@@ -5,6 +5,7 @@
 <div x-data="{
         ...createCRUDMixin('{{ entity_type }}', {}, {}),
         ...createNotesMixin('{{ entity_type }}'),
+        mode: 'view', // 'new', 'view', 'edit'
         
         {% if config.tabs %}
         activeTab: '{{ config.tabs[0].key }}',
@@ -15,19 +16,52 @@
         {% endif %}
         
         async load{{ entity_type|title }}(id) {
+            this.mode = 'view';
             await this.loadEntity(id);
             this.openModal();
         },
         
+        openNew{{ entity_type|title }}() {
+            this.mode = 'new';
+            this.{{ entity_type }} = { ...{{ config.default_values|tojson }} };
+            this.openModal();
+        },
+        
+        enableEdit() {
+            this.mode = 'edit';
+        },
+        
         async save{{ entity_type|title }}Details() {
-            return await this.saveEntity();
+            if (this.mode === 'new') {
+                return await this.createEntity();
+            } else {
+                return await this.saveEntity();
+            }
+        },
+        
+        get modalTitle() {
+            if (this.mode === 'new') return 'Create New {{ config.title_singular or entity_type|title }}';
+            if (this.mode === 'edit') return 'Edit {{ config.title_singular or entity_type|title }}';
+            return '{{ config.title }}';
+        },
+        
+        get isReadonly() {
+            return this.mode === 'view';
         }
      }" 
      @open-detail-{{ entity_type }}-modal.window="load{{ entity_type|title }}($event.detail.id)"
+     @open-new-{{ entity_type }}-modal.window="openNew{{ entity_type|title }}()"
      @close-modal.window="closeModal()">
 
     {% call base_modal(entity_type + '-detail-modal', backdrop_click_close=false) %}
-        {{ modal_header(config.title) }}
+        <div class="modal-header">
+            <h3 class="modal-title" id="modal-title" x-text="modalTitle"></h3>
+            <button @click="show = false" class="modal-close-button">
+                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
         
         <div x-show="loading" class="text-center py-8">
             <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
@@ -74,7 +108,44 @@
             {% endif %}
         </div>
         
-        {{ modal_footer(save_action="save" + entity_type|title + "Details()", save_text="Save Changes") }}
+        <div class="modal-footer">
+            <button @click="show = false" class="modal-cancel-button">
+                Cancel
+            </button>
+            <template x-if="mode === 'view'">
+                <button @click="enableEdit()" class="modal-save-button">
+                    Edit
+                </button>
+            </template>
+            <template x-if="mode === 'edit'">
+                <button @click="save{{ entity_type|title }}Details()"
+                        :disabled="saving"
+                        class="modal-save-button">
+                    <span x-show="!saving">Save Changes</span>
+                    <span x-show="saving" class="flex items-center">
+                        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        Saving...
+                    </span>
+                </button>
+            </template>
+            <template x-if="mode === 'new'">
+                <button @click="save{{ entity_type|title }}Details()"
+                        :disabled="saving"
+                        class="modal-save-button">
+                    <span x-show="!saving">Create {{ config.title_singular or entity_type|title }}</span>
+                    <span x-show="saving" class="flex items-center">
+                        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        Creating...
+                    </span>
+                </button>
+            </template>
+        </div>
     {% endcall %}
 </div>
 {% endmacro %}
@@ -85,21 +156,24 @@
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <input type="text" x-model="{{ entity_type }}.{{ field.name }}" 
-                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                       :readonly="isReadonly"
+                       :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'"
                        placeholder="{{ field.placeholder | default('') }}">
             </div>
         {% elif field.type == 'textarea' %}
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <textarea x-model="{{ entity_type }}.{{ field.name }}" 
-                          class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                          :readonly="isReadonly"
+                          :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'"
                           rows="{{ field.rows | default(3) }}"></textarea>
             </div>
         {% elif field.type == 'select' %}
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <select x-model="{{ entity_type }}.{{ field.name }}" 
-                        class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        :disabled="isReadonly"
+                        :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'">
                     {% for option in field.options %}
                     <option value="{{ option.value if option is mapping else option }}">
                         {{ option.label if option is mapping else option|title }}
@@ -111,7 +185,8 @@
             <div>
                 <label class="text-form-label">{{ field.label }}</label>
                 <input type="date" x-model="{{ entity_type }}.{{ field.name }}" 
-                       class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                       :readonly="isReadonly"
+                       :class="isReadonly ? 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-gray-50 cursor-not-allowed' : 'w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500'">
             </div>
         {% elif field.type == 'grid' %}
             <div class="grid grid-cols-{{ field.columns | default(2) }} gap-4">

--- a/app/templates/components/modals/configs/entity_modal_configs.html
+++ b/app/templates/components/modals/configs/entity_modal_configs.html
@@ -129,6 +129,30 @@
             "name": "name",
             "label": "Full Name",
             "placeholder": "Contact name"
+        },
+        {
+            "type": "grid",
+            "columns": 2,
+            "fields": [
+                {
+                    "type": "text",
+                    "name": "email",
+                    "label": "Email",
+                    "placeholder": "Contact email"
+                },
+                {
+                    "type": "text",
+                    "name": "phone",
+                    "label": "Phone",
+                    "placeholder": "Contact phone number"
+                }
+            ]
+        },
+        {
+            "type": "text",
+            "name": "role",
+            "label": "Role",
+            "placeholder": "Job title or role"
         }
     ]
 } %}
@@ -150,6 +174,66 @@
             "name": "name",
             "label": "Company Name",
             "placeholder": "Company name"
+        },
+        {
+            "type": "grid",
+            "columns": 2,
+            "fields": [
+                {
+                    "type": "select",
+                    "name": "industry",
+                    "label": "Industry",
+                    "options": [
+                        {"value": "", "label": "Select industry"},
+                        {"value": "technology", "label": "Technology"},
+                        {"value": "finance", "label": "Finance"},
+                        {"value": "healthcare", "label": "Healthcare"},
+                        {"value": "manufacturing", "label": "Manufacturing"},
+                        {"value": "retail", "label": "Retail"},
+                        {"value": "education", "label": "Education"},
+                        {"value": "consulting", "label": "Consulting"},
+                        {"value": "other", "label": "Other"}
+                    ]
+                },
+                {
+                    "type": "select",
+                    "name": "size",
+                    "label": "Company Size",
+                    "options": [
+                        {"value": "", "label": "Select size"},
+                        {"value": "startup", "label": "Startup (1-10)"},
+                        {"value": "small", "label": "Small (11-50)"},
+                        {"value": "medium", "label": "Medium (51-200)"},
+                        {"value": "large", "label": "Large (201-1000)"},
+                        {"value": "enterprise", "label": "Enterprise (1000+)"}
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "grid",
+            "columns": 2,
+            "fields": [
+                {
+                    "type": "text",
+                    "name": "website",
+                    "label": "Website",
+                    "placeholder": "https://company.com"
+                },
+                {
+                    "type": "text",
+                    "name": "phone",
+                    "label": "Phone",
+                    "placeholder": "Company phone number"
+                }
+            ]
+        },
+        {
+            "type": "textarea",
+            "name": "address",
+            "label": "Address",
+            "rows": 2,
+            "placeholder": "Company address"
         }
     ]
 } %}
@@ -172,6 +256,49 @@
             "name": "name",
             "label": "Opportunity Name",
             "placeholder": "Opportunity name"
+        },
+        {
+            "type": "grid",
+            "columns": 2,
+            "fields": [
+                {
+                    "type": "text",
+                    "name": "value",
+                    "label": "Value ($)",
+                    "placeholder": "Opportunity value"
+                },
+                {
+                    "type": "select",
+                    "name": "stage",
+                    "label": "Stage",
+                    "options": [
+                        {"value": "", "label": "Select stage"},
+                        {"value": "lead", "label": "Lead"},
+                        {"value": "qualified", "label": "Qualified"},
+                        {"value": "proposal", "label": "Proposal"},
+                        {"value": "negotiation", "label": "Negotiation"},
+                        {"value": "closed_won", "label": "Closed Won"},
+                        {"value": "closed_lost", "label": "Closed Lost"}
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "grid",
+            "columns": 2,
+            "fields": [
+                {
+                    "type": "text",
+                    "name": "probability",
+                    "label": "Probability (%)",
+                    "placeholder": "0-100"
+                },
+                {
+                    "type": "date",
+                    "name": "expected_close_date",
+                    "label": "Expected Close Date"
+                }
+            ]
         }
     ]
 } %}

--- a/app/templates/components/modals/configs/entity_modal_configs.html
+++ b/app/templates/components/modals/configs/entity_modal_configs.html
@@ -121,7 +121,7 @@
         "email": "",
         "phone": "",
         "role": "",
-        "company": null
+        "company_id": ""
     },
     "fields": [
         {
@@ -160,13 +160,15 @@
 {# Company Detail Modal Configuration #}
 {% set company_detail_config = {
     "title": "Company Details",
+    "title_singular": "Company",
     "show_notes": true,
     "default_values": {
         "name": "",
         "industry": "",
+        "size": "",
         "website": "",
-        "contacts": [],
-        "opportunities": []
+        "phone": "",
+        "address": ""
     },
     "fields": [
         {
@@ -246,9 +248,9 @@
         "name": "",
         "value": "",
         "stage": "",
-        "probability": 0,
+        "probability": "",
         "expected_close_date": "",
-        "company": null
+        "company_id": ""
     },
     "fields": [
         {


### PR DESCRIPTION
## Summary
• Fixed "horribly formatted" global search detail modals to match "New" modal styling
• Implemented DRY solution using existing generic modal system  
• All modals (New/View/Edit) now have consistent formatting and layout

## Test Plan
✅ **Verified via browser testing:**
- [x] Global search → company detail modal shows all fields with proper grid layout
- [x] New Company page loads without errors and modal opens correctly
- [x] All modals use same CSS classes and spacing (`modal-body modal-content-spacing`)
- [x] No JavaScript errors or breaking changes
- [x] Existing functionality preserved

## Key Changes  
- **Expanded entity modal configs** with complete field definitions (grid layouts)
- **Added proper modal container styling** to generic detail template
- **Created missing companies/new.html** template for route compatibility
- **No code duplication** - leveraged existing modal components

## Evidence
Detail modals now display:
- Company Name, Industry, Company Size (side-by-side)  
- Website, Phone (side-by-side)
- Address field
- Notes section with proper spacing

**Result**: Search modals look exactly like "New" modals ✅