### PR TITLE
Fix modal button styling and add save confirmation

### DIFF
--- a/app/static/css/modals.css
+++ b/app/static/css/modals.css
@@ -151,7 +151,32 @@
 
 /* Modal Save Button - now just use universal btn-primary */
 .modal-save-button {
-    /* This class now inherits from btn-primary for consistency */
+    background-color: #2563eb;
+    color: white;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-radius: 0.5rem;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    transform: scale(1);
+}
+
+.modal-save-button:hover {
+    background-color: #1d4ed8;
+    transform: scale(1.05);
+}
+
+.modal-save-button:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #3b82f6, 0 0 0 4px rgba(59, 130, 246, 0.5);
+}
+
+.modal-save-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: scale(1);
 }
 
 /* ========== Form Elements ========== */

--- a/app/static/js/modal-mixins.js
+++ b/app/static/js/modal-mixins.js
@@ -130,6 +130,20 @@ function createCRUDMixin(entityType, defaultEntity = {}, options = {}) {
         async saveEntity() {
             if (!this.validateEntity()) return;
             
+            // Show confirmation dialog if enabled
+            if (this.confirmBeforeSave !== false) {
+                const entityName = entityType.charAt(0).toUpperCase() + entityType.slice(1);
+                const isUpdate = !!this[`${entityKey}Id`];
+                const action = isUpdate ? 'update' : 'create';
+                const confirmMessage = this.getConfirmMessage ? 
+                    this.getConfirmMessage(action, entityName) : 
+                    `Are you sure you want to save changes to this ${entityName.toLowerCase()}?`;
+                
+                if (!confirm(confirmMessage)) {
+                    return;
+                }
+            }
+            
             this.setSaving(true);
             
             try {
@@ -183,12 +197,16 @@ function createCRUDMixin(entityType, defaultEntity = {}, options = {}) {
             return true;
         },
         
+        // Configuration options
+        confirmBeforeSave: true,
+        
         // Event handlers for modals to override
         onEntityLoaded: null,
         onEntitySaved: null,
         onFormReset: null,
         customValidation: null,
         getRequiredFields: null,
+        getConfirmMessage: null,
         
         ...options
     });


### PR DESCRIPTION
## Summary
- Fix inconsistent modal button styling by implementing proper btn-primary styles for modal-save-button
- Add confirmation dialog functionality to CRUD mixin before saving changes
- Ensure DRY compliance with existing button patterns

## Changes Made
- `app/static/css/modals.css`: Implemented full btn-primary styling for modal-save-button class
- `app/static/js/modal-mixins.js`: Added confirmBeforeSave functionality to CRUD mixin with customizable confirmation messages

## Test Plan
- [x] Verify button styling matches other primary buttons in the application  
- [x] Test confirmation dialog appears when saving entity changes
- [x] Confirm save functionality works after user confirms
- [x] Ensure no regressions in existing modal workflows

## Fixes Issues
- Resolves inconsistent button appearance across modals
- Addresses missing save confirmations for Tasks, Companies, and other entities