### PR TITLE
fix: complete stakeholder template macro naming

### DIFF
--- a/app/templates/components/stakeholder_card.html
+++ b/app/templates/components/stakeholder_card.html
@@ -2,7 +2,7 @@
 {% from "components/ui_elements.html" import pluralized_count %}
 
 {# Stakeholder field configuration - clean, declarative setup #}
-{% set contact_field_config = {
+{% set stakeholder_field_config = {
     'title_field': 'name',
     'secondary_fields': [
         {'field': 'role', 'type': 'text'}
@@ -12,46 +12,46 @@
     ]
 } %}
 
-{# Custom secondary info handler for contact company link #}
-{% macro contact_secondary_info(contact) %}
-{% if contact.role %}{{ contact.role }} • {% endif %}
+{# Custom secondary info handler for stakeholder company link #}
+{% macro stakeholder_secondary_info(stakeholder) %}
+{% if stakeholder.role %}{{ stakeholder.role }} • {% endif %}
 <span class="text-link-interactive" 
-      onclick="event.stopPropagation(); openCompanyDetailModal({{ contact.company.id }})">
-    <span class="text-entity-base text-color-company">{{ contact.company.name }}</span>
+      onclick="event.stopPropagation(); openCompanyDetailModal({{ stakeholder.company.id }})">
+    <span class="text-entity-base text-color-company">{{ stakeholder.company.name }}</span>
 </span>
 {% endmacro %}
 
-{% macro render_contact(contact) %}
-{{ expandable_card('contact', contact, contact.id,
+{% macro render_stakeholder(stakeholder) %}
+{{ expandable_card('stakeholder', stakeholder, stakeholder.id,
     expansion_enabled=true,
-    field_config=contact_field_config,
-    secondary_info=contact_secondary_info(contact),
-    action_buttons=action_buttons_row('contact', contact.id)) }}
+    field_config=stakeholder_field_config,
+    secondary_info=stakeholder_secondary_info(stakeholder),
+    action_buttons=action_buttons_row('stakeholder', stakeholder.id)) }}
 {% endmacro %}
 
-{% macro contact_expanded_content(contact) %}
+{% macro stakeholder_expanded_content(stakeholder) %}
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <!-- Stakeholder Details -->
     <div>
         <h4 class="text-sm font-medium text-gray-900 mb-2">Stakeholder Details</h4>
         <div class="space-y-2 text-sm">
-            {% if contact.email %}
+            {% if stakeholder.email %}
                 <div class="flex items-center">
                     {{ envelope_icon("w-4 h-4 text-gray-400 mr-2") }}
-                    <a href="mailto:{{ contact.email }}" class="text-blue-600 hover:text-blue-800">
-                        {{ contact.email }}
+                    <a href="mailto:{{ stakeholder.email }}" class="text-blue-600 hover:text-blue-800">
+                        {{ stakeholder.email }}
                     </a>
                 </div>
             {% endif %}
-            {% if contact.phone %}
+            {% if stakeholder.phone %}
                 <div class="flex items-center">
                     {{ phone_icon("w-4 h-4 text-gray-400 mr-2") }}
-                    <a href="tel:{{ contact.phone }}" class="text-green-600 hover:text-green-800">
-                        {{ contact.phone }}
+                    <a href="tel:{{ stakeholder.phone }}" class="text-green-600 hover:text-green-800">
+                        {{ stakeholder.phone }}
                     </a>
                 </div>
             {% endif %}
-            {% if not contact.email and not contact.phone %}
+            {% if not stakeholder.email and not stakeholder.phone %}
                 <p class="text-gray-500 italic">No contact information available</p>
             {% endif %}
         </div>
@@ -61,17 +61,17 @@
     <div>
         <h4 class="text-sm font-medium text-gray-900 mb-2">Quick Actions</h4>
         <div class="quick-actions-grid">
-            <button @click.stop="createTask({{ contact.id }})" 
+            <button @click.stop="createTask({{ stakeholder.id }})" 
                     class="quick-action-btn quick-action-btn-primary">
                 Add Task
             </button>
-            <button @click.stop="createOpportunity({{ contact.id }})" 
+            <button @click.stop="createOpportunity({{ stakeholder.id }})" 
                     class="quick-action-btn quick-action-btn-secondary">
                 New Opportunity
             </button>
-            {% if contact.opportunities %}
+            {% if stakeholder.opportunities %}
                 <span class="px-3 py-1 bg-gray-100 text-gray-700 rounded-md text-sm">
-                    {{ pluralized_count(contact.opportunities|length, 'opportunity', short=true) }}
+                    {{ pluralized_count(stakeholder.opportunities|length, 'opportunity', short=true) }}
                 </span>
             {% endif %}
         </div>


### PR DESCRIPTION
## Summary
- Fix UndefinedError in stakeholders template by renaming render_contact to render_stakeholder
- Complete the contact-to-stakeholder transformation in stakeholder_card.html template
- Update all variable references and macro names to use consistent stakeholder terminology

## Test plan
- [x] Stakeholders page loads without template errors
- [x] Template renders stakeholder data correctly 
- [x] All macro references use proper stakeholder naming convention