### PR TITLE
Fix run.sh port range issue

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -31,7 +31,7 @@ trap cleanup SIGINT SIGTERM
 
 # Get free ports
 CRM_PORT=$(find_free_port 5050)
-CHATBOT_PORT=$(find_free_port 8009)
+CHATBOT_PORT=$(find_free_port 8020 50)
 
 echo "🚀 Starting CRM application on http://127.0.0.1:$CRM_PORT"
 echo "🤖 Starting chatbot service on port $CHATBOT_PORT"


### PR DESCRIPTION
## Summary
- Fixed run.sh script failing when chatbot ports 8009-8018 were occupied
- Expanded chatbot port search range from 8009-8018 to 8020-8069 (50 attempts)

## Test plan
- [x] Verified all ports 8009-8018 were occupied by other Python processes
- [x] Tested run.sh script successfully finds free ports and starts both services
- [x] Confirmed CRM application and chatbot service start properly