### PR TITLE
fix: prevent duplicate structured logging in Flask debug mode

### DIFF
--- a/services/crm/main.py
+++ b/services/crm/main.py
@@ -67,9 +67,10 @@ def create_app():
     app.config["SQLALCHEMY_DATABASE_URI"] = get_database_path()
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
-    # ADR-012: Configure structured logging
-    setup_structured_logging(app, "crm-service")
-    app.logger.info('CRM Application startup with structured logging')
+    # ADR-012: Configure structured logging (only in reloader process, not initial)
+    if os.environ.get('WERKZEUG_RUN_MAIN'):
+        setup_structured_logging(app, "crm-service")
+        app.logger.info('CRM Application startup with structured logging')
         
     # Enable Jinja2 do extension for template logic
     app.jinja_env.add_extension('jinja2.ext.do')


### PR DESCRIPTION
## Summary
- Fixes duplicate structured logging messages in Flask debug mode
- Prevents logging configuration from running twice (main + reloader processes)

## Changes
- Modified `services/crm/main.py` to only configure structured logging in reloader process
- Uses `WERKZEUG_RUN_MAIN` environment variable to detect reloader process

## Test plan
- [x] Start application and verify no duplicate log messages
- [x] Confirm CSS/styling remains unaffected 
- [x] Verify application functionality works correctly