### PR TITLE
fix: populate empty dropdowns for stakeholders and teams

### DIFF
--- a/app/models/stakeholder.py
+++ b/app/models/stakeholder.py
@@ -161,7 +161,12 @@ class Stakeholder(BaseModel):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Foreign key to company
-    company_id = db.Column(db.Integer, db.ForeignKey("companies.id"), nullable=False)
+    company_id = db.Column(db.Integer, db.ForeignKey("companies.id"), nullable=False, info={
+        'display_label': 'Company',
+        'groupable': True,
+        'relationship_field': 'company',
+        'relationship_display_field': 'name'
+    })
 
     # Relationships (use back_populates to avoid conflicts)
     company = db.relationship("Company", back_populates="stakeholders")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -42,6 +42,40 @@ class User(BaseModel):
         'display_label': 'Job Title',
         'groupable': True
     })  # Single source of truth for role
+    department = db.Column(db.String(100), info={
+        'display_label': 'Department',
+        'groupable': True,
+        'choices': {
+            'sales': {
+                'label': 'Sales',
+                'description': 'Sales and business development'
+            },
+            'engineering': {
+                'label': 'Engineering',
+                'description': 'Software development and engineering'
+            },
+            'marketing': {
+                'label': 'Marketing',
+                'description': 'Marketing and communications'
+            },
+            'support': {
+                'label': 'Support',
+                'description': 'Customer support and success'
+            },
+            'operations': {
+                'label': 'Operations',
+                'description': 'Business operations and administration'
+            },
+            'finance': {
+                'label': 'Finance',
+                'description': 'Finance and accounting'
+            },
+            'hr': {
+                'label': 'Human Resources',
+                'description': 'Human resources and people operations'
+            }
+        }
+    })
     created_at = db.Column(db.DateTime, default=datetime.utcnow, info={'display_label': 'Created At'})
 
     def to_dict(self):

--- a/app/utils/core/base_handlers.py
+++ b/app/utils/core/base_handlers.py
@@ -431,6 +431,27 @@ class EntityGrouper:
     def __init__(self, model_class, entity_name):
         self.model_class = model_class
         self.entity_name = entity_name
+    
+    def _get_relationship_info(self, field_name):
+        """Check if field is a relationship field and return its metadata"""
+        # Look through all columns to find foreign key with relationship metadata
+        for attr_name in dir(self.model_class):
+            try:
+                attr = getattr(self.model_class, attr_name)
+                if hasattr(attr, 'property') and hasattr(attr.property, 'columns') and len(attr.property.columns) > 0:
+                    column = attr.property.columns[0]
+                    info = column.info
+                    
+                    # Check if this field has relationship metadata pointing to our field
+                    if (info.get('relationship_field') == field_name and 
+                        info.get('groupable', False)):
+                        return {
+                            'display_field': info.get('relationship_display_field', 'name'),
+                            'foreign_key_field': attr_name
+                        }
+            except (AttributeError, TypeError):
+                continue
+        return None
         
     
     def group_by_field(self, entities, group_by, custom_grouper=None):
@@ -445,8 +466,22 @@ class EntityGrouper:
         # Default grouping logic
         grouped = defaultdict(list)
         
-        # Generic field-based grouping
-        if hasattr(self.model_class, group_by):
+        # Check if this is a relationship field by examining model metadata
+        relationship_info = self._get_relationship_info(group_by)
+        
+        if relationship_info:
+            # Handle relationship-based grouping
+            for entity in entities:
+                related_obj = getattr(entity, group_by, None)
+                if related_obj:
+                    # Get the display field value from the related object
+                    display_field = relationship_info.get('display_field', 'name')
+                    key = getattr(related_obj, display_field, str(related_obj))
+                else:
+                    key = f"No {group_by.replace('_', ' ').title()}"
+                grouped[str(key)].append(entity)
+        elif hasattr(self.model_class, group_by):
+            # Generic field-based grouping  
             for entity in entities:
                 field_value = getattr(entity, group_by, None)
                 key = str(field_value) if field_value is not None else "Other"

--- a/app/utils/core/model_introspection.py
+++ b/app/utils/core/model_introspection.py
@@ -151,9 +151,18 @@ class ModelIntrospector:
                     
                     # Add field only once if it's groupable and not already added
                     if is_groupable and attr_name not in seen_fields:
-                        label = info.get('display_label', attr_name.replace('_', ' ').title())
-                        groupable_fields.append((attr_name, label))
-                        seen_fields.add(attr_name)
+                        # Handle relationship fields - use relationship name instead of foreign key name
+                        if info.get('relationship_field'):
+                            # Use relationship field name (e.g., 'company' instead of 'company_id')
+                            field_name = info['relationship_field']
+                            label = info.get('display_label', field_name.replace('_', ' ').title())
+                        else:
+                            # Regular field
+                            field_name = attr_name
+                            label = info.get('display_label', attr_name.replace('_', ' ').title())
+                        
+                        groupable_fields.append((field_name, label))
+                        seen_fields.add(field_name)
             except (AttributeError, TypeError):
                 continue
         

--- a/tools/database/seed_data.py
+++ b/tools/database/seed_data.py
@@ -151,20 +151,61 @@ CONTACT_NAMES = [
 
 JOB_TITLES = [
     "CEO",
-    "CTO",
+    "CTO", 
     "VP of Sales",
     "Marketing Director",
     "Operations Manager",
-    "Project Manager",
+    "Project Manager", 
     "Business Development",
     "Product Manager",
     "IT Director",
     "CFO",
     "Sales Manager",
-    "Technical Lead",
     "Account Manager",
-    "Senior Developer",
-    "HR Director",
+    "Solutions Engineer",
+    "Customer Success Manager",
+    "Technical Lead",
+    "Software Engineer",
+    "Marketing Manager",
+    "HR Manager",
+    "Finance Manager"
+]
+
+DEPARTMENTS = [
+    "sales",
+    "engineering", 
+    "marketing",
+    "support",
+    "operations",
+    "finance",
+    "hr"
+]
+
+# Enhanced job titles for stakeholders and team members
+STAKEHOLDER_JOB_TITLES = [
+    "CEO",
+    "CTO",
+    "VP of Sales",
+    "Marketing Director", 
+    "Operations Manager",
+    "IT Director",
+    "CFO",
+    "VP Engineering",
+    "Head of Product",
+    "Chief Revenue Officer"
+]
+
+TEAM_JOB_TITLES = [
+    "Sales Manager",
+    "Account Manager", 
+    "Solutions Engineer",
+    "Customer Success Manager",
+    "Technical Lead",
+    "Software Engineer",
+    "Marketing Manager",
+    "HR Manager",
+    "Finance Manager",
+    "Business Development Manager"
 ]
 
 # Team member names for seeding User model
@@ -415,7 +456,7 @@ def create_contacts(companies):
 
             contact = Stakeholder(
                 name=name,
-                job_title=random.choice(JOB_TITLES),
+                job_title=random.choice(STAKEHOLDER_JOB_TITLES),
                 email=email if has_email else None,
                 phone=(
                     f"+1-{random.randint(100,999)}-{random.randint(100,999)}-{random.randint(1000,9999)}"
@@ -444,7 +485,8 @@ def create_team_members():
         team_member = User(
             name=name,
             email=email,
-            job_title=random.choice(JOB_TITLES)
+            job_title=random.choice(TEAM_JOB_TITLES),
+            department=random.choice(DEPARTMENTS)
         )
         team_members.append(team_member)
         db.session.add(team_member)


### PR DESCRIPTION
## Summary
- Fixed empty group by dropdowns for stakeholders and account teams
- Stakeholders dropdown now shows: Company, Job Title  
- Teams dropdown now shows: Department, Job Title
- Implemented DRY solution using existing ADR-016 metadata patterns

## Key Changes
- ✅ **Enhanced Model Metadata**: Added groupable relationship metadata to Stakeholder model (company field)
- ✅ **New Department Field**: Added department field with choices to User model for team grouping
- ✅ **Extended ModelIntrospector**: Auto-detects relationship-based groupable fields  
- ✅ **Generic Relationship Grouper**: Single grouper handles all entities automatically
- ✅ **Enhanced Seed Data**: Added diverse job titles and departments for meaningful grouping

## Technical Implementation
- Leverages existing metadata patterns from ADR-016 (no overengineering)
- Uses relationship metadata to map `stakeholder.company_id` → `stakeholder.company.name`
- Generic grouper eliminates need for custom grouper functions per entity
- Future entities get dropdown support automatically with `groupable: true` metadata

## Test Plan
- [x] Stakeholders page shows populated dropdown with Company/Job Title options
- [x] Teams page shows populated dropdown with Department/Job Title options  
- [x] Dropdown selection triggers HTMX content refresh
- [x] Database reseeded with diverse data for testing grouping scenarios
- [x] All existing functionality preserved (companies page unaffected)