### PR TITLE
fix: replace string manipulation with metadata system for plural/singular handling

### DIFF
--- a/app/config/entity_config.py
+++ b/app/config/entity_config.py
@@ -93,16 +93,18 @@ class EntityConfigRegistry:
             cls._model_registry = {}
             
             for model_class in all_models:
-                # Use model's table name as the key
-                entity_type = model_class.__tablename__.rstrip('s')
+                # Use model metadata for proper singular/plural handling
+                from app.utils.model_registry import ModelRegistry
+                model_name = model_class.__name__.lower()
+                metadata = ModelRegistry.get_model_metadata(model_name)
+
+                # Register by singular display name
+                entity_type = metadata.display_name.lower()
                 cls._model_registry[entity_type] = model_class
-                
-                # Also add any explicit entity type mapping
-                if hasattr(model_class, '__entity_config__'):
-                    config = model_class.__entity_config__
-                    endpoint_name = config.get('endpoint_name')
-                    if endpoint_name:
-                        cls._model_registry[endpoint_name.rstrip('s')] = model_class
+
+                # Also register by plural display name
+                plural_type = metadata.display_name_plural.lower()
+                cls._model_registry[plural_type] = model_class
                         
         except ImportError:
             # Fallback if models aren't available

--- a/app/forms/base/builders.py
+++ b/app/forms/base/builders.py
@@ -657,12 +657,10 @@ class DropdownConfigGenerator:
                 plural_label = model_class.__entity_config__.get('display_name', 'Items')
                 filter_name = f'All {plural_label}'
         
-        # HTMX targets using model configuration
-        singular = entity_name.rstrip('s')  # Simple fallback
-        if model_class:
-            config = model_class.__entity_config__
-            # Use display name singular for more accurate mapping
-            singular = config.get('display_name_singular', singular).lower().replace(' ', '-')
+        # HTMX targets using model metadata
+        from app.utils.model_registry import ModelRegistry
+        metadata = ModelRegistry.get_model_metadata(model_class.__name__.lower())
+        singular = metadata.display_name.lower().replace(' ', '-')
         
         hx_target = f'#{singular}-content'
         hx_get = f'/{entity_name}/content'

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -111,6 +111,17 @@ class EntityModel(BaseModel):
 
             # Register with the exact endpoint name from entity config
             ModelRegistry.register_model(cls, endpoint_name)
+            ModelRegistry.register_model(cls, cls.__name__.lower())
+
+            # Register both singular and plural forms using metadata
+            metadata = ModelRegistry.get_model_metadata(cls.__name__.lower())
+            singular_name = metadata.display_name.lower()
+            plural_name = metadata.display_name_plural.lower()
+
+            if singular_name not in ModelRegistry._models:
+                ModelRegistry._models[singular_name] = cls
+            if plural_name not in ModelRegistry._models:
+                ModelRegistry._models[plural_name] = cls
 
     @classmethod
     def get_entity_config(cls) -> Dict[str, Any]:

--- a/app/templates/macros/cards.html
+++ b/app/templates/macros/cards.html
@@ -34,10 +34,10 @@
   {{ card(stakeholder, overrides={'actions': custom_actions}) }}
 #}
 {% macro card(entity, expansion_enabled=true, card_classes='', content=none, overrides={}) %}
-{# Extract entity type from table name and get singular form #}
-{% set entity_type_plural = entity.__tablename__.rstrip('s') %}
-{% set labels = get_entity_labels(entity_type_plural) %}
-{% set entity_type = labels.singular.lower() %}
+{# Get entity type from metadata #}
+{% set metadata = get_model_metadata(entity.__class__.__name__.lower()) %}
+{% set entity_type = metadata.display_name.lower() %}
+{% set entity_type_plural = metadata.display_name_plural.lower() %}
 
 {% if content is none %}
     {% set content = build_dynamic_card_config(entity_type_plural, entity) %}

--- a/app/utils/context_builders.py
+++ b/app/utils/context_builders.py
@@ -201,7 +201,7 @@ class UniversalContextBuilder:
             entity_name=metadata.display_name_plural,
             entity_name_singular=metadata.display_name,
             entity_description=metadata.description or f"Manage your {metadata.display_name_plural.lower()}",
-            entity_type=entity_name.rstrip('s'),
+            entity_type=metadata.display_name.lower(),
             entity_endpoint=metadata.api_endpoint,
             entity_buttons=entity_buttons
         )

--- a/app/utils/model_registry.py
+++ b/app/utils/model_registry.py
@@ -132,7 +132,43 @@ class ModelRegistry:
             'singular': metadata.display_name,
             'plural': metadata.display_name_plural
         }
-    
+
+    @classmethod
+    def auto_register_from_entity_config(cls):
+        """
+        Auto-register models that have __entity_config__ (transitional method)
+
+        This method provides backward compatibility during migration from
+        legacy __entity_config__ patterns to the new registry system.
+        """
+        # Import here to avoid circular dependencies
+        try:
+            from app.utils.core.model_introspection import get_all_entity_models
+
+            all_models = get_all_entity_models()
+            for model_class in all_models:
+                if hasattr(model_class, '__entity_config__'):
+                    # Use endpoint_name from entity config as registry key
+                    config = model_class.__entity_config__
+                    endpoint_name = config.get('endpoint_name', model_class.__name__.lower())
+
+                    # Register with both endpoint name and class name
+                    cls.register_model(model_class, endpoint_name)
+                    cls.register_model(model_class, model_class.__name__.lower())
+
+                    # Register both singular and plural forms using metadata
+                    metadata = cls.get_model_metadata(model_class.__name__.lower())
+                    singular_name = metadata.display_name.lower()
+                    plural_name = metadata.display_name_plural.lower()
+
+                    if singular_name not in cls._models:
+                        cls._models[singular_name] = model_class
+                    if plural_name not in cls._models:
+                        cls._models[plural_name] = model_class
+
+        except ImportError:
+            # Graceful fallback if model_introspection not available
+            pass
     
     @classmethod
     def clear_cache(cls):

--- a/docs/adr/ADR-011-simple-css-architecture.md
+++ b/docs/adr/ADR-011-simple-css-architecture.md
@@ -114,9 +114,9 @@ def get_entity_labels(entity_type: str) -> Dict[str, str]:
 ```jinja2
 <!-- Simplified template usage -->
 {% macro card(entity) %}
-{% set entity_type_plural = entity.__tablename__.rstrip('s') %}
-{% set labels = get_entity_labels(entity_type_plural) %}
-{% set entity_type = labels.singular.lower() %}
+{% set metadata = get_model_metadata(entity.__class__.__name__.lower()) %}
+{% set entity_type = metadata.display_name.lower() %}
+{% set entity_type_plural = metadata.display_name_plural.lower() %}
 <div class="{{entity_type}}-card">
     <!-- Renders as: company-card, task-card, etc. -->
 </div>


### PR DESCRIPTION
## Summary
- Replace all `.rstrip('s')` and `+ 's'` violations with proper metadata system usage
- Modernize codebase to use `metadata.display_name` and `metadata.display_name_plural`
- Remove all string manipulation fallbacks as mandated

## Test plan
- [x] Updated 7 files with proper metadata usage
- [x] Eliminated all `.rstrip('s')` violations
- [x] Updated ADR-011 example to show correct pattern
- [ ] Run application to verify metadata system works correctly