### PR TITLE
Fix get_model_metadata template error - DRY metadata access

### DIFF
--- a/app/utils/ui/template_globals.py
+++ b/app/utils/ui/template_globals.py
@@ -133,7 +133,11 @@ def get_model_form_fields(model_name):
 
 
 def get_model_config(model_class):
-    """Get complete model configuration for templates."""
+    """Get complete model configuration for templates.
+
+    DEPRECATED: Use ModelRegistry.get_model_metadata() instead.
+    This function will be removed in a future version.
+    """
     return ModelIntrospector.get_model_config(model_class)
 
 

--- a/services/crm/main.py
+++ b/services/crm/main.py
@@ -110,7 +110,6 @@ def create_app():
     # Register clean template functions - no more string hacks!
     app.jinja_env.globals["get_field_options"] = get_field_options
     app.jinja_env.globals["get_model_form_fields"] = get_model_form_fields
-    app.jinja_env.globals["get_model_config"] = get_model_config
     # app.jinja_env.globals["get_create_modal_config"] = get_create_modal_config  # Removed
     # app.jinja_env.globals["get_detail_modal_config"] = get_detail_modal_config  # Removed
     # app.jinja_env.globals["get_all_modal_configs"] = get_all_modal_configs  # Removed
@@ -129,6 +128,7 @@ def create_app():
     
     # Dynamic card system
     app.jinja_env.globals["build_dynamic_card_config"] = CardConfigBuilder.build_card_config
+    app.jinja_env.globals["get_model_metadata"] = ModelRegistry.get_model_metadata
     app.jinja_env.globals["getattr"] = getattr
     app.jinja_env.globals["hasattr"] = hasattr
     


### PR DESCRIPTION
## Summary
- Fixed undefined `get_model_metadata` error in `macros/cards.html:38`
- Consolidated metadata access to use `ModelRegistry` as single source of truth
- Deprecated legacy `get_model_config()` function to eliminate duplication

## Key Changes
- **Added**: `ModelRegistry.get_model_metadata` to template globals in `services/crm/main.py:132`
- **Removed**: Redundant `get_model_config` from template globals to eliminate duplication
- **Deprecated**: Legacy `get_model_config()` function with clear migration path

## Problem Solved
Templates were calling `get_model_metadata()` but only legacy config functions were exposed to Jinja. This caused 500 errors on `/teams/content` and other entity pages.

## Test Plan
- [x] Verified `/teams/content` loads without errors (HTTP 200)
- [x] Tested all entity content pages for regressions:
  - `/companies/content` - ✅ HTTP 200
  - `/tasks/content` - ✅ HTTP 200
  - `/opportunities/content` - ✅ HTTP 200
  - `/stakeholders/content` - ✅ HTTP 200
- [x] Confirmed metadata access works through modern registry system
- [x] Legacy functions properly deprecated with migration guidance

## Benefits
- **Single source of truth**: All metadata through `ModelRegistry`
- **Eliminates duplication**: Removes redundant metadata functions
- **Future-proof**: Modern registry pattern vs legacy introspection
- **Template consistency**: Clear separation of data vs UI concerns