### PR TITLE
Remove Python icon functions, use entity names directly

### DIFF
--- a/app/config/entity_config.py
+++ b/app/config/entity_config.py
@@ -182,10 +182,6 @@ class EntityConfigRegistry:
         """Get configuration for an entity type - built dynamically from models"""
         return cls._build_config(entity_type)
     
-    @classmethod
-    def get_icon(cls, entity_type: str) -> str:
-        """Get icon name for entity type"""
-        return cls.get_config(entity_type).icon
     
     @classmethod
     def get_labels(cls, entity_type: str) -> Dict[str, str]:
@@ -224,11 +220,6 @@ class EntityConfigRegistry:
 def get_entity_config(entity_type: str) -> EntityConfig:
     """Get complete entity configuration"""
     return EntityConfigRegistry.get_config(entity_type)
-
-
-def get_entity_icon(entity_type: str) -> str:
-    """Get icon name for entity"""
-    return EntityConfigRegistry.get_icon(entity_type)
 
 
 def get_entity_labels(entity_type: str) -> Dict[str, str]:

--- a/app/routes/web/search.py
+++ b/app/routes/web/search.py
@@ -17,12 +17,12 @@ def get_searchable_entity_types():
         if model_class:
             # Get friendly name and icon
             friendly_names = {
-                'company': {'name': 'Companies', 'icon': '🏢'},
-                'stakeholder': {'name': 'Contacts', 'icon': '👤'}, 
-                'opportunity': {'name': 'Opportunities', 'icon': '💼'},
-                'task': {'name': 'Tasks', 'icon': '✅'}
+                'company': {'name': 'Companies', 'icon': 'company'},
+                'stakeholder': {'name': 'Contacts', 'icon': 'stakeholder'},
+                'opportunity': {'name': 'Opportunities', 'icon': 'opportunity'},
+                'task': {'name': 'Tasks', 'icon': 'task'}
             }
-            entity_types[model_name] = friendly_names.get(model_name, {'name': model_name.title(), 'icon': '📄'})
+            entity_types[model_name] = friendly_names.get(model_name, {'name': model_name.title(), 'icon': model_name})
             
     return entity_types
 

--- a/app/templates/macros/core/entity_helpers.html
+++ b/app/templates/macros/core/entity_helpers.html
@@ -21,7 +21,7 @@
 #}
 {% from 'macros/base/icons.html' import icon %}
 {% macro entity_icon(entity_type, size='md', additional_classes='') %}
-{{ icon(get_entity_icon(entity_type), size, additional_classes) }}
+{{ icon(entity_type, size, additional_classes) }}
 {% endmacro %}
 
 {#

--- a/app/templates/macros/empty_state.html
+++ b/app/templates/macros/empty_state.html
@@ -21,7 +21,7 @@
   {% set config = get_empty_state_config(entity_type) %}
   {% set display_title = title or config.title %}
   {% set display_subtitle = subtitle or config.subtitle %}
-  {% set display_icon = icon_name or get_entity_icon(entity_type) %}
+  {% set display_icon = icon_name or entity_type %}
   
   <div class="empty-state-container {{ additional_classes }}">
     {{ icon(display_icon, 'xl', 'empty-state-icon') }}

--- a/app/utils/ui/template_globals.py
+++ b/app/utils/ui/template_globals.py
@@ -3,9 +3,8 @@
 from app.models import db
 from app.utils.core.model_introspection import ModelIntrospector, get_model_by_name
 from app.config.entity_config import (
-    get_entity_config, 
-    get_entity_icon, 
-    get_entity_labels, 
+    get_entity_config,
+    get_entity_labels,
     get_empty_state_config
 )
 # Modal configs removed - using WTForms modal system now (keeping main branch approach)

--- a/services/crm/main.py
+++ b/services/crm/main.py
@@ -41,7 +41,6 @@ from app.utils.ui.template_globals import (
     PRIORITY_OPTIONS,
     SIZE_OPTIONS,
     get_entity_config,
-    get_entity_icon, 
     get_entity_labels,
     get_empty_state_config,
     get_dashboard_action_buttons,
@@ -123,7 +122,6 @@ def create_app():
     
     # Entity configuration functions - now in Python backend
     app.jinja_env.globals["get_entity_config"] = get_entity_config
-    app.jinja_env.globals["get_entity_icon"] = get_entity_icon
     app.jinja_env.globals["get_entity_labels"] = get_entity_labels
     app.jinja_env.globals["get_empty_state_config"] = get_empty_state_config
     


### PR DESCRIPTION
## Summary
- Remove unnecessary Python icon mapping functions
- Use entity names directly in templates for icon rendering
- Replace hardcoded emoji icons with proper entity names

## Changes Made
- ❌ Remove `get_entity_icon()` from `entity_config.py`
- ❌ Remove Jinja global registration from `main.py`
- ✅ Update templates to use `{{ icon(entity_type, 'size') }}` directly
- ✅ Replace emoji icons (🏢, 👤, 💼, ✅) with entity names in search.py

## Benefits
- Cleaner separation of concerns - Python passes data, templates handle presentation
- Consistent with existing CSS styling pattern
- Eliminates unnecessary Python icon mapping layer
- Simpler, more maintainable code

## Test Plan
- [x] Application starts without errors
- [x] Icons render correctly on dashboard
- [x] Search functionality works with new entity names
- [x] Templates compile without missing function errors