### PR TITLE
feat: DRY global search with modal integration

### DIFF
--- a/app/routes/web/search.py
+++ b/app/routes/web/search.py
@@ -5,7 +5,116 @@ from app.utils.core.model_introspection import get_model_by_name
 
 search_bp = Blueprint("search", __name__)
 
-# Get searchable entity types from model map  
+# DRY entity configuration for dynamic search results
+ENTITY_CONFIGS = {
+    'company': {
+        'model': Company,
+        'type_label': 'company',
+        'search_fields': ['name', 'industry'],
+        'title_field': 'name',
+        'subtitle_fields': ['industry'],
+        'icon': '🏢'
+    },
+    'stakeholder': {
+        'model': Stakeholder,
+        'type_label': 'contact',
+        'search_fields': ['name', 'email', 'job_title'],
+        'title_field': 'name',
+        'subtitle_fields': ['job_title', 'company.name'],
+        'icon': '👤',
+        'joins': [Company]
+    },
+    'opportunity': {
+        'model': Opportunity,
+        'type_label': 'opportunity',
+        'search_fields': ['name', 'company.name'],
+        'title_field': 'name',
+        'subtitle_fields': ['company.name', 'value'],
+        'icon': '💼',
+        'joins': [Company]
+    },
+    'task': {
+        'model': Task,
+        'type_label': 'task',
+        'search_fields': ['description'],
+        'title_field': 'description',
+        'subtitle_fields': ['due_date', 'priority'],
+        'icon': '✅'
+    }
+}
+
+def generate_entity_result(entity, entity_type, config):
+    """Generate a standardized search result for any entity type"""
+    title = getattr(entity, config['title_field'])
+
+    # Build subtitle dynamically from configured fields
+    subtitle_parts = []
+    for field in config.get('subtitle_fields', []):
+        if '.' in field:
+            # Handle nested fields like 'company.name'
+            obj = entity
+            for part in field.split('.'):
+                obj = getattr(obj, part, None)
+                if obj is None:
+                    break
+            if obj:
+                subtitle_parts.append(str(obj))
+        else:
+            value = getattr(entity, field, None)
+            if value:
+                # Special formatting for different field types
+                if field == 'value' and hasattr(entity, 'value'):
+                    subtitle_parts.append(f"${value:,.0f}")
+                elif field == 'due_date' and hasattr(entity, 'due_date'):
+                    subtitle_parts.append(f'Due: {value.strftime("%m/%d/%y")}')
+                else:
+                    subtitle_parts.append(str(value))
+
+    return {
+        "id": entity.id,
+        "type": config['type_label'],
+        "title": title,
+        "subtitle": " • ".join(subtitle_parts) if subtitle_parts else "",
+        "url": f"/modals/{entity_type}/{entity.id}/view",
+        "icon": config.get('icon', '📄')
+    }
+
+def search_entities(entity_type, query, limit, config):
+    """DRY search function for any entity type"""
+    model = config['model']
+
+    # Build base query
+    base_query = model.query
+
+    # Add joins if specified
+    if 'joins' in config:
+        for join_model in config['joins']:
+            base_query = base_query.join(join_model)
+
+    if query:
+        # Build search conditions dynamically
+        search_conditions = []
+        for field in config['search_fields']:
+            if '.' in field:
+                # Handle nested fields like 'company.name'
+                obj = model
+                for part in field.split('.')[:-1]:
+                    # Get the relationship
+                    obj = getattr(obj, part).property.mapper.class_
+                field_name = field.split('.')[-1]
+                search_attr = getattr(obj, field_name)
+            else:
+                search_attr = getattr(model, field)
+
+            search_conditions.append(search_attr.ilike(f"%{query}%"))
+
+        entities = base_query.filter(or_(*search_conditions)).limit(limit).all()
+    else:
+        entities = base_query.limit(limit).all()
+
+    return [generate_entity_result(entity, entity_type, config) for entity in entities]
+
+# Get searchable entity types from model map
 def get_searchable_entity_types():
     """Get searchable entity types dynamically from model introspection"""
     # These are the models we want to include in search
@@ -33,143 +142,7 @@ def search():
     entity_type = request.args.get("type", "all")
     limit = min(int(request.args.get("limit", 20)), 50)
 
-    # Handle comma-separated entity types dynamically
-    searchable_types = get_searchable_entity_types()
-    if entity_type == "all":
-        entity_types = list(searchable_types.keys())
-    else:
-        entity_types = [t.strip() for t in entity_type.split(",") if t.strip() in searchable_types]
-        if not entity_types:
-            entity_types = list(searchable_types.keys())
-
-    results = []
-
-    if "company" in entity_types:
-        if query:
-            companies = (
-                Company.query.filter(
-                    or_(
-                        Company.name.ilike(f"%{query}%"),
-                        Company.industry.ilike(f"%{query}%"),
-                    )
-                )
-                .limit(limit)
-                .all()
-            )
-        else:
-            # Return all companies when no query
-            companies = Company.query.limit(limit).all()
-
-        for company in companies:
-            results.append(
-                {
-                    "id": company.id,
-                    "type": "company",
-                    "title": company.name,
-                    "subtitle": company.industry,
-                    "url": f"/companies/{company.id}",
-                }
-            )
-
-    if "stakeholder" in entity_types:
-        if query:
-            contacts = (
-                Stakeholder.query.join(Company)
-                .filter(
-                    or_(
-                        Stakeholder.name.ilike(f"%{query}%"),
-                        Stakeholder.email.ilike(f"%{query}%"),
-                        Stakeholder.job_title.ilike(f"%{query}%"),
-                    )
-                )
-                .limit(limit)
-                .all()
-            )
-        else:
-            # Return all contacts when no query
-            contacts = Stakeholder.query.join(Company).limit(limit).all()
-
-        for contact in contacts:
-            results.append(
-                {
-                    "id": contact.id,
-                    "type": "contact",
-                    "title": contact.name,
-                    "subtitle": (
-                        f"{contact.job_title} at {contact.company.name}"
-                        if contact.job_title
-                        else contact.company.name
-                    ),
-                    "url": f"/contacts/{contact.id}",
-                }
-            )
-
-    if "opportunity" in entity_types:
-        if query:
-            opportunities = (
-                Opportunity.query.join(Company)
-                .filter(
-                    or_(
-                        Opportunity.name.ilike(f"%{query}%"),
-                        Company.name.ilike(f"%{query}%"),
-                    )
-                )
-                .limit(limit)
-                .all()
-            )
-        else:
-            # Return all opportunities when no query
-            opportunities = Opportunity.query.join(Company).limit(limit).all()
-
-        for opportunity in opportunities:
-            results.append(
-                {
-                    "id": opportunity.id,
-                    "type": "opportunity",
-                    "title": opportunity.name,
-                    "subtitle": (
-                        f"{opportunity.company.name} • ${opportunity.value:,.0f}"
-                        if opportunity.value
-                        else opportunity.company.name
-                    ),
-                    "url": f"/opportunities/{opportunity.id}",
-                }
-            )
-
-    if "task" in entity_types:
-        if query:
-            tasks = (
-                Task.query.filter(Task.description.ilike(f"%{query}%"))
-                .limit(limit)
-                .all()
-            )
-        else:
-            # Return all tasks when no query
-            tasks = Task.query.limit(limit).all()
-
-        for task in tasks:
-            results.append(
-                {
-                    "id": task.id,
-                    "type": "task",
-                    "title": task.description,
-                    "subtitle": (
-                        f'Due: {task.due_date.strftime("%m/%d/%y")}'
-                        if task.due_date
-                        else "No due date"
-                    ),
-                    "url": f"/tasks/{task.id}",
-                }
-            )
-
-    # Sort by relevance if there's a query, otherwise by type and title
-    if query:
-        results.sort(key=lambda x: query.lower() in x["title"].lower(), reverse=True)
-    else:
-        # Sort by type first, then by title
-        type_order = {"company": 0, "contact": 1, "opportunity": 2, "task": 3}
-        results.sort(key=lambda x: (type_order.get(x["type"], 4), x["title"].lower()))
-
+    results = _perform_search(query, entity_type, limit)
     return jsonify(results[:limit])
 
 
@@ -287,103 +260,12 @@ def _perform_search(query, entity_type, limit):
 
     results = []
 
-    if "company" in entity_types:
-        if query:
-            companies = (
-                Company.query.filter(
-                    or_(
-                        Company.name.ilike(f"%{query}%"),
-                        Company.industry.ilike(f"%{query}%"),
-                    )
-                )
-                .limit(limit)
-                .all()
-            )
-        else:
-            companies = Company.query.limit(limit).all()
-
-        for company in companies:
-            results.append({
-                "id": company.id,
-                "type": "company",
-                "title": company.name,
-                "subtitle": f"{company.industry} • {company.address}" if company.industry and company.address else (company.industry or company.address or ""),
-                "url": f"/companies/{company.id}",
-            })
-
-    if "stakeholder" in entity_types:
-        if query:
-            contacts = (
-                Stakeholder.query.join(Company)
-                .filter(
-                    or_(
-                        Stakeholder.name.ilike(f"%{query}%"),
-                        Stakeholder.email.ilike(f"%{query}%"),
-                        Company.name.ilike(f"%{query}%"),
-                    )
-                )
-                .limit(limit)
-                .all()
-            )
-        else:
-            contacts = Stakeholder.query.join(Company).limit(limit).all()
-
-        for contact in contacts:
-            results.append({
-                "id": contact.id,
-                "type": "contact",
-                "title": contact.name,
-                "subtitle": (
-                    f"{contact.job_title} at {contact.company.name}"
-                    if contact.job_title
-                    else contact.company.name
-                ),
-                "url": f"/contacts/{contact.id}",
-            })
-
-    if "opportunity" in entity_types:
-        if query:
-            opportunities = (
-                Opportunity.query.join(Company)
-                .filter(
-                    or_(
-                        Opportunity.name.ilike(f"%{query}%"),
-                        Company.name.ilike(f"%{query}%"),
-                    )
-                )
-                .limit(limit)
-                .all()
-            )
-        else:
-            opportunities = Opportunity.query.join(Company).limit(limit).all()
-
-        for opportunity in opportunities:
-            results.append({
-                "id": opportunity.id,
-                "type": "opportunity",
-                "title": opportunity.name,
-                "subtitle": f"{opportunity.company.name} • ${opportunity.value:,.0f}" if opportunity.value else opportunity.company.name,
-                "url": f"/opportunities/{opportunity.id}",
-            })
-
-    if "task" in entity_types:
-        if query:
-            tasks = (
-                Task.query.filter(Task.description.ilike(f"%{query}%"))
-                .limit(limit)
-                .all()
-            )
-        else:
-            tasks = Task.query.limit(limit).all()
-
-        for task in tasks:
-            results.append({
-                "id": task.id,
-                "type": "task",
-                "title": task.description,
-                "subtitle": f"{task.priority} priority" if task.priority else "No priority set",
-                "url": f"/tasks/{task.id}",
-            })
+    # Use DRY search for all configured entity types
+    for entity_type in entity_types:
+        if entity_type in ENTITY_CONFIGS:
+            config = ENTITY_CONFIGS[entity_type]
+            entity_results = search_entities(entity_type, query, limit, config)
+            results.extend(entity_results)
 
     # Sort results by type and title
     if results:

--- a/app/routes/web/search.py
+++ b/app/routes/web/search.py
@@ -73,6 +73,7 @@ def generate_entity_result(entity, entity_type, config):
     return {
         "id": entity.id,
         "type": config['type_label'],
+        "model_type": entity_type,  # Add model type for modal system
         "title": title,
         "subtitle": " • ".join(subtitle_parts) if subtitle_parts else "",
         "url": f"/modals/{entity_type}/{entity.id}/view",

--- a/app/templates/components/search_results.html
+++ b/app/templates/components/search_results.html
@@ -35,7 +35,7 @@
 
             <!-- Content using universal entity_link macro -->
             <div class="min-w-0 flex-1">
-                {{ entity_link(result.type, result.id, result.title, mode='modal', subtitle=result.subtitle) }}
+                {{ entity_link(result.model_type, result.id, result.title, mode='modal', subtitle=result.subtitle) }}
             </div>
 
             <!-- Type label -->

--- a/app/templates/components/search_results.html
+++ b/app/templates/components/search_results.html
@@ -8,6 +8,7 @@
   - results: List of search result objects with id, type, title, subtitle, url
   - query: The search query string
 #}
+{% from 'macros/base/buttons.html' import entity_link %}
 
 {% if results %}
 <div class="py-1">
@@ -18,10 +19,8 @@
     {% endif %}
 
     {% for result in results %}
-    <a href="{{ result.url }}"
-       class="group block px-4 py-3 hover:bg-blue-50 border-b border-gray-100 last:border-b-0 transition-colors duration-150"
-       data-search-result="{{ result.type }}">
-        <div class="flex items-center space-x-3">
+    <div class="border-b border-gray-100 last:border-b-0" data-search-result="{{ result.type }}">
+        <div class="flex items-center space-x-3 px-4 py-3">
             <!-- Type icon -->
             <div class="flex-shrink-0">
                 <span class="inline-flex items-center justify-center w-8 h-8 rounded-full text-sm
@@ -30,24 +29,13 @@
                     {% elif result.type == 'opportunity' %}bg-purple-100 text-purple-600
                     {% elif result.type == 'task' %}bg-orange-100 text-orange-600
                     {% else %}bg-gray-100 text-gray-600{% endif %}">
-                    {% if result.type == 'company' %}🏢
-                    {% elif result.type == 'contact' %}👤
-                    {% elif result.type == 'opportunity' %}💼
-                    {% elif result.type == 'task' %}✅
-                    {% else %}📄{% endif %}
+{{ result.icon if result.icon else '📄' }}
                 </span>
             </div>
 
-            <!-- Content -->
+            <!-- Content using universal entity_link macro -->
             <div class="min-w-0 flex-1">
-                <div class="text-sm font-semibold text-gray-900 truncate group-hover:text-blue-700 transition-colors">
-                    {{ result.title }}
-                </div>
-                {% if result.subtitle %}
-                <div class="text-xs text-gray-500 truncate mt-1">
-                    {{ result.subtitle }}
-                </div>
-                {% endif %}
+                {{ entity_link(result.type, result.id, result.title, mode='modal', subtitle=result.subtitle) }}
             </div>
 
             <!-- Type label -->
@@ -62,7 +50,7 @@
                 </span>
             </div>
         </div>
-    </a>
+    </div>
     {% endfor %}
 </div>
 {% else %}

--- a/app/templates/macros/base/buttons.html
+++ b/app/templates/macros/base/buttons.html
@@ -143,13 +143,60 @@
 {% endmacro %}
 
 {#
+  Universal Entity Link - DRY solution for all entity linking across the app
+
+  Supports both navigation and modal modes. Follows ADR-014 DRY patterns.
+  Eliminates duplication between search results, tables, cards, etc.
+
+  Parameters:
+  - entity_type (required): Type of entity ('company', 'contact', 'opportunity', 'task')
+  - entity_id (required): ID of the entity
+  - text (required): Link text to display
+  - mode (optional): 'navigate' for standard links, 'modal' for modal opening (default: 'navigate')
+  - subtitle (optional): Additional text to display below main text
+  - classes (optional): Additional CSS classes
+
+  Usage:
+  {{ entity_link('company', 123, 'Acme Corp', mode='modal') }}
+  {{ entity_link('task', 456, 'Review proposal', mode='navigate') }}
+  {{ entity_link('contact', 789, 'John Doe', subtitle='CEO at Acme Corp', mode='modal') }}
+#}
+{% macro entity_link(entity_type, entity_id, text, mode='navigate', subtitle='', classes='') %}
+{% if mode == 'modal' %}
+<a href="#"
+   onclick="window.dispatchEvent(new CustomEvent('open-detail-{{ entity_type }}-modal', { detail: { id: {{ entity_id }}, readOnly: true } })); return false;"
+   class="group block hover:bg-blue-50 transition-colors duration-150 {{ classes }}"
+   data-entity-type="{{ entity_type }}"
+   data-entity-id="{{ entity_id }}">
+    <div class="text-sm font-semibold text-gray-900 truncate group-hover:text-blue-700 transition-colors">
+        {{ text }}
+    </div>
+    {% if subtitle %}
+    <div class="text-xs text-gray-500 truncate mt-1">
+        {{ subtitle }}
+    </div>
+    {% endif %}
+</a>
+{% else %}
+<a href="/{{ entity_type }}s/{{ entity_id }}" class="{{ classes }}">
+    {{ text }}
+    {% if subtitle %}
+    <div class="text-xs text-gray-500 truncate mt-1">
+        {{ subtitle }}
+    </div>
+    {% endif %}
+</a>
+{% endif %}
+{% endmacro %}
+
+{#
   Entity Link Button - Standardized link button for entity details
-  
+
   Parameters:
   - url (required): URL to link to
   - text (optional): Button text (default: 'View Details')
   - classes (optional): Additional CSS classes
-  
+
   Usage:
   {{ entity_link_button(url_for('companies.detail', id=company.id)) }}
   {{ entity_link_button('/stakeholders/123', 'View Stakeholder') }}


### PR DESCRIPTION
## Summary
- Implemented universal `entity_link()` macro following ADR-014 DRY patterns
- Replaced 100+ lines of duplicated search code with configurable `ENTITY_CONFIGS`
- Fixed global search to open modals instead of navigating to non-existent pages
- Added model type mapping to correctly route modals (stakeholder vs contact)

## Test plan
- [x] Search for "michael" returns contacts, tasks, companies
- [x] Clicking contact opens stakeholder modal with correct data
- [x] Modal shows "View stakeholder" with full contact details
- [x] Search uses existing modal event system (no new JavaScript)
- [x] All entity types use consistent DRY patterns

## Technical Details
**DRY Improvements:**
- Universal `ENTITY_CONFIGS` eliminates search duplication
- Single `entity_link()` macro replaces custom HTML across templates
- Dynamic field mapping reduces hardcoded logic
- Follows established ADR-008 and ADR-014 patterns

**Modal Integration:**
- Search results trigger existing `open-detail-{type}-modal` events
- Uses established `/modals/{model}/{id}/view` routing
- Leverages existing modal handlers (no new code needed)
- Fixed model name mapping (contact → stakeholder)

Closes search modal functionality issues.