### PR TITLE
fix: make entire global search result row clickable

### DIFF
--- a/app/templates/components/search_results.html
+++ b/app/templates/components/search_results.html
@@ -20,7 +20,11 @@
 
     {% for result in results %}
     <div class="border-b border-gray-100 last:border-b-0" data-search-result="{{ result.type }}">
-        <div class="flex items-center space-x-3 px-4 py-3">
+        <a href="#"
+           onclick="window.dispatchEvent(new CustomEvent('open-detail-{{ result.model_type }}-modal', { detail: { id: {{ result.id }}, readOnly: true } })); return false;"
+           class="flex items-center space-x-3 px-4 py-3 block hover:bg-blue-50 transition-colors duration-150"
+           data-entity-type="{{ result.model_type }}"
+           data-entity-id="{{ result.id }}">
             <!-- Type icon -->
             <div class="flex-shrink-0">
                 <span class="inline-flex items-center justify-center w-8 h-8 rounded-full text-sm
@@ -33,9 +37,16 @@
                 </span>
             </div>
 
-            <!-- Content using universal entity_link macro -->
+            <!-- Content -->
             <div class="min-w-0 flex-1">
-                {{ entity_link(result.model_type, result.id, result.title, mode='modal', subtitle=result.subtitle) }}
+                <div class="text-sm font-semibold text-gray-900 truncate hover:text-blue-700 transition-colors">
+                    {{ result.title }}
+                </div>
+                {% if result.subtitle %}
+                <div class="text-xs text-gray-500 truncate mt-1">
+                    {{ result.subtitle }}
+                </div>
+                {% endif %}
             </div>
 
             <!-- Type label -->
@@ -49,7 +60,7 @@
                     {{ result.type }}
                 </span>
             </div>
-        </div>
+        </a>
     </div>
     {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- Made entire search result rows clickable instead of just the text portion
- Improved user experience with larger click targets
- Maintained all existing functionality and styling

## Changes
- Restructured search result HTML to wrap entire content in anchor element
- Removed nested entity_link macro to avoid duplicate links  
- Preserved hover effects across full row width

## Test Plan
- [ ] Search for various entities (companies, contacts, opportunities, tasks)
- [ ] Click anywhere on a search result row (icon, text, or type label)
- [ ] Verify modal opens correctly for each entity type
- [ ] Check hover effects work across entire row
- [ ] Confirm no visual regressions