### PR TITLE
Fix modal interactions and remove animations

### DIFF
--- a/app/templates/components/search_results.html
+++ b/app/templates/components/search_results.html
@@ -21,7 +21,9 @@
     {% for result in results %}
     <div class="border-b border-gray-100 last:border-b-0" data-search-result="{{ result.type }}">
         <a href="#"
-           onclick="window.dispatchEvent(new CustomEvent('open-detail-{{ result.model_type }}-modal', { detail: { id: {{ result.id }}, readOnly: true } })); return false;"
+           hx-get="{{ url_for('modals.view_modal', model_name=result.model_type, entity_id=result.id) }}"
+           hx-target="body"
+           hx-swap="beforeend"
            class="flex items-center space-x-3 px-4 py-3 block hover:bg-blue-50 transition-colors duration-150"
            data-entity-type="{{ result.model_type }}"
            data-entity-id="{{ result.id }}">

--- a/app/templates/macros/modals/base.html
+++ b/app/templates/macros/modals/base.html
@@ -51,8 +51,8 @@
             {{ title }}
         </h3>
     </div>
-    <button onclick="this.closest('.modal-overlay').remove()" 
-            class="modal-close-button text-gray-400 hover:text-gray-600 transition-colors">
+    <button onclick="this.closest('.modal-overlay').remove()"
+            class="modal-close-button text-gray-400 hover:text-gray-600">
         {{ icon('x-mark', 'lg') }}
     </button>
 </div>


### PR DESCRIPTION
## Summary
- Remove animation from modal close button for instant hover state changes
- Fix search results modal error by replacing JavaScript events with proper HTMX requests

## Changes Made
- **Modal Close Button**: Removed `transition-colors` class to eliminate animation delay
- **Search Results**: Replaced `onclick` JavaScript event dispatch with `hx-get` requests to `/modals/{model_name}/{entity_id}/view` endpoints

## Test Plan
- [x] Modal close button responds instantly to hover
- [x] Search results now properly open entity view modals instead of showing errors
- [x] Read-only entity information displays correctly in modal