### PR TITLE
Fix Recent Notes styling and entity display issues

### DIFF
--- a/app/models/note.py
+++ b/app/models/note.py
@@ -34,6 +34,27 @@ class Note(BaseModel):
     entity_id = db.Column(db.Integer)
 
     @property
+    def company_name(self) -> Optional[str]:
+        """Get company name from the entity this note is attached to."""
+        if not self.entity_type or not self.entity_id:
+            return None
+
+        if self.entity_type == "company":
+            from .company import Company
+            entity = Company.query.get(self.entity_id)
+            return entity.name if entity else None
+        elif self.entity_type == "stakeholder":
+            from .stakeholder import Stakeholder
+            entity = Stakeholder.query.get(self.entity_id)
+            return entity.company.name if entity and entity.company else None
+        elif self.entity_type == "opportunity":
+            from .opportunity import Opportunity
+            entity = Opportunity.query.get(self.entity_id)
+            return entity.company.name if entity and entity.company else None
+
+        return None
+
+    @property
     def entity_name(self) -> Optional[str]:
         """
         Get the name of the entity this note is attached to.
@@ -118,6 +139,7 @@ class Note(BaseModel):
         
         # Add note-specific computed fields
         result['entity_name'] = self.entity_name
+        result['company_name'] = self.company_name
         result['content_preview'] = self.content[:100] + '...' if len(self.content) > 100 else self.content
         result['created_at_display'] = self.created_at_display
 

--- a/app/templates/macros/ui/card_items.html
+++ b/app/templates/macros/ui/card_items.html
@@ -41,7 +41,17 @@
     <div class="text-card-title line-clamp-3">{{ note.content }}</div>
     <div class="text-card-meta">
         {{ smart_date_display(note.created_at, context="created") }}
-        {%- if note.entity_name %} • {{ note.entity_name }}{% endif %}
+        {%- if note.entity_type == "company" and note.entity_name %}
+            • <span class="text-company-name">{{ note.entity_name }}</span>
+        {%- elif note.entity_type == "opportunity" and note.entity_name %}
+            • <span class="text-opportunity-value">{{ note.entity_name }}</span>
+            {%- if note.company_name %} • <span class="text-company-name">{{ note.company_name }}</span>{% endif %}
+        {%- elif note.entity_type == "stakeholder" and note.entity_name %}
+            • <span class="text-stakeholder-name">{{ note.entity_name }}</span>
+            {%- if note.company_name %} • <span class="text-company-name">{{ note.company_name }}</span>{% endif %}
+        {%- elif note.entity_name %}
+            • {{ note.entity_name }}
+        {%- endif %}
     </div>
 {% endcall %}
 {% endmacro %}

--- a/app/templates/macros/ui/date_formatting.html
+++ b/app/templates/macros/ui/date_formatting.html
@@ -26,10 +26,10 @@
         {% set display_label = label or ("Due" if context == "due" else "Created" if context == "created" else "Updated" if context == "updated" else "") %}
 
         {# Determine CSS class based on context and date relationship #}
-        {% if is_overdue %}
-            {% set date_class = "date-overdue" %}
-        {% elif context in ["created", "updated"] %}
+        {% if context in ["created", "updated"] %}
             {% set date_class = "date-increment" %}
+        {% elif is_overdue %}
+            {% set date_class = "date-overdue" %}
         {% elif is_future %}
             {% set date_class = "date-decrement" %}
         {% else %}


### PR DESCRIPTION
## Summary
- Fixed created dates incorrectly using overdue (red) styling instead of increment (gray)
- Added proper semantic colors for entity names in Recent Notes section
- Split company and opportunity names when notes are attached to opportunities

## Test plan
- [x] Start application and check dashboard Recent Notes section
- [x] Verify created dates show in gray (date-increment) not red (date-overdue)
- [x] Verify company names show in blue (text-company-name)
- [x] Verify opportunity names show in green (text-opportunity-value)
- [x] Verify when note attached to opportunity, both opportunity and company names are visible