### PR TITLE
perf: remove all modal and dropdown animations for snappier UX

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -50,77 +50,27 @@
     --modal-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
     --modal-radius: 1rem;
     --modal-backdrop: rgba(0, 0, 0, 0.6);
-    --modal-animation: 150ms cubic-bezier(0.4, 0, 0.2, 1);
     --modal-max-height: 90vh;
 }
 
-/* Modal Animations */
-@keyframes modalFadeIn {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-@keyframes modalSlideIn {
-    from {
-        opacity: 0;
-        transform: translateY(10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes modalFadeOut {
-    from {
-        opacity: 1;
-    }
-    to {
-        opacity: 0;
-    }
-}
-
-@keyframes modalSlideOut {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(10px);
-    }
-}
-
-/* Modal Overlay Styling */
+/* Modal Overlay Styling - No animations */
 .modal-overlay {
-    animation: modalFadeIn var(--modal-animation) forwards;
+    /* Instant visibility changes only */
 }
 
-.modal-overlay.modal-fade-out {
-    animation: modalFadeOut var(--modal-animation) forwards;
-}
-
-/* Modal Backdrop Styling */
+/* Modal Backdrop Styling - No animations */
 .modal-backdrop {
     backdrop-filter: blur(2px);
     -webkit-backdrop-filter: blur(2px);
     background: var(--modal-backdrop);
-    transition: opacity var(--modal-animation);
+    /* Removed transition */
 }
 
-/* Modal Content Styling */
+/* Modal Content Styling - No animations */
 .modal-content {
-    animation: modalSlideIn var(--modal-animation) forwards;
     box-shadow: var(--modal-shadow);
     max-height: var(--modal-max-height);
-}
-
-.modal-fade-out .modal-content {
-    animation: modalSlideOut var(--modal-animation) forwards;
+    /* Removed animations */
 }
 
 /* Modal Header Styling */

--- a/app/static/js/alpine/entityLinker.js
+++ b/app/static/js/alpine/entityLinker.js
@@ -36,33 +36,41 @@ window.entityLinker = (config) => {
             this.updateHiddenField();
         },
         
-        // Search functionality
+        // Search functionality - DISABLED auto-suggestions
         async searchEntities(force = false) {
+            // Disabled: No longer show suggestions automatically
+            // Keep the function for potential manual search button usage
+            this.suggestions = [];
+            this.showDropdown = false;
+            return;
+
+            // Original search code commented out but preserved
+            /*
             // Always search if forced (on focus), otherwise need at least some text
             if (!force && this.search.length < 1) {
                 this.suggestions = [];
                 this.showDropdown = false;
                 return;
             }
-            
+
             this.isSearching = true;
             try {
                 const response = await fetch(`/api/search?q=${encodeURIComponent(this.search)}&limit=10`);
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
-                
+
                 const results = await response.json();
-                
+
                 // Filter by allowed entity types
                 const allowedTypes = entityTypes.split(',').map(t => t.trim());
-                this.suggestions = results.filter(item => 
-                    allowedTypes.includes(item.type) || 
+                this.suggestions = results.filter(item =>
+                    allowedTypes.includes(item.type) ||
                     allowedTypes.includes(item.entity_type)
                 );
-                
+
                 this.showDropdown = this.suggestions.length > 0;
-                
+
             } catch (error) {
                 console.error('Entity search error:', error);
                 this.suggestions = [];
@@ -70,6 +78,7 @@ window.entityLinker = (config) => {
             } finally {
                 this.isSearching = false;
             }
+            */
         },
         
         // Selection management

--- a/app/templates/components/chat_widget.html
+++ b/app/templates/components/chat_widget.html
@@ -12,7 +12,7 @@
     <!-- Chat Toggle Button -->
     <button 
         @click="toggleChat()" 
-        class="bg-blue-500 hover:bg-blue-600 text-white rounded-full w-16 h-16 flex items-center justify-center shadow-lg transition-all duration-200 focus:outline-none focus:ring-4 focus:ring-blue-300"
+        class="bg-blue-500 hover:bg-blue-600 text-white rounded-full w-16 h-16 flex items-center justify-center shadow-lg focus:outline-none focus:ring-4 focus:ring-blue-300"
         :class="{ 'scale-110': isOpen }"
         aria-label="Open chat assistant"
     >
@@ -21,14 +21,8 @@
     </button>
     
     <!-- Chat Panel -->
-    <div 
-        x-show="isOpen" 
-        x-transition:enter="transition ease-out duration-200"
-        x-transition:enter-start="transform translate-y-2 opacity-0 scale-95"
-        x-transition:enter-end="transform translate-y-0 opacity-100 scale-100"
-        x-transition:leave="transition ease-in duration-150"
-        x-transition:leave-start="transform translate-y-0 opacity-100 scale-100"
-        x-transition:leave-end="transform translate-y-2 opacity-0 scale-95"
+    <div
+        x-show="isOpen"
         class="absolute bottom-20 right-0 w-80 h-96 bg-white rounded-lg shadow-xl border border-gray-200 flex flex-col"
         style="display: none;"
         role="dialog"
@@ -96,9 +90,9 @@
             <div x-show="isTyping" class="flex justify-start" aria-label="Assistant is typing">
                 <div class="bg-gray-100 text-gray-800 px-4 py-2 rounded-lg text-sm">
                     <div class="flex space-x-1" aria-hidden="true">
-                        <div class="w-2 h-2 bg-gray-400 rounded-full animate-bounce"></div>
-                        <div class="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style="animation-delay: 0.1s"></div>
-                        <div class="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style="animation-delay: 0.2s"></div>
+                        <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
+                        <div class="w-2 h-2 bg-gray-400 rounded-full ml-1"></div>
+                        <div class="w-2 h-2 bg-gray-400 rounded-full ml-1"></div>
                     </div>
                 </div>
             </div>
@@ -117,7 +111,7 @@
                 >
                 <button 
                     type="submit"
-                    class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 disabled:bg-gray-300 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium disabled:bg-gray-300 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500"
                     :disabled="!currentMessage.trim() || connectionStatus !== 'connected'"
                     aria-label="Send message"
                 >

--- a/app/templates/components/modals/alpine_modal.html
+++ b/app/templates/components/modals/alpine_modal.html
@@ -12,23 +12,11 @@
 
     <!-- Modal Backdrop -->
     <div x-show="isOpen"
-         x-transition:enter="ease-out duration-300"
-         x-transition:enter-start="opacity-0"
-         x-transition:enter-end="opacity-100"
-         x-transition:leave="ease-in duration-200"
-         x-transition:leave-start="opacity-100"
-         x-transition:leave-end="opacity-0"
          @click="closeModal()"
          class="fixed inset-0" style="background-color: rgba(17, 24, 39, 0.6);"></div>
 
     <!-- Modal Content -->
     <div x-show="isOpen"
-         x-transition:enter="ease-out duration-300"
-         x-transition:enter-start="opacity-0 transform scale-95"
-         x-transition:enter-end="opacity-100 transform scale-100"
-         x-transition:leave="ease-in duration-200"
-         x-transition:leave-start="opacity-100 transform scale-100"
-         x-transition:leave-end="opacity-0 transform scale-95"
          @click.stop
          class="relative bg-white rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[90vh] overflow-hidden border border-gray-200">
 
@@ -65,9 +53,6 @@
 
                 <!-- General Error with icon -->
                 <div x-show="errors.general"
-                     x-transition:enter="transition ease-out duration-200"
-                     x-transition:enter-start="opacity-0 transform scale-95"
-                     x-transition:enter-end="opacity-100 transform scale-100"
                      class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md mb-4 flex items-start">
                     <svg class="w-5 h-5 text-red-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
@@ -179,12 +164,12 @@
             <div class="flex justify-end space-x-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
                 <button @click="closeModal()"
                         :disabled="saving"
-                        class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 transition-colors duration-200 shadow-sm">
+                        class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 shadow-sm">
                     Cancel
                 </button>
                 <button @click="submitForm()"
                         :disabled="saving || Object.keys(errors).length > 0"
-                        class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200 shadow-sm">
+                        class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm">
                     <span x-show="!saving">Save</span>
                     <span x-show="saving" class="flex items-center">
                         <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">

--- a/app/templates/components/modals/wtforms_modal.html
+++ b/app/templates/components/modals/wtforms_modal.html
@@ -55,14 +55,14 @@
     {% call htmx_modal_footer() %}
         <button type="button"
                 onclick="this.closest('.modal-overlay').remove()"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 shadow-sm">
+                class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-sm">
             Close
         </button>
         <button type="button"
                 hx-get="{{ url_for('modals.edit_modal', model_name=model_name, entity_id=entity_id) }}"
                 hx-target=".modal-overlay"
                 hx-swap="outerHTML"
-                class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 shadow-sm">
+                class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-sm">
             Edit
         </button>
     {% endcall %}
@@ -109,12 +109,12 @@
         {% call htmx_modal_footer() %}
             <button type="button"
                     onclick="this.closest('.modal-overlay').remove()"
-                    class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 shadow-sm">
+                    class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 shadow-sm">
                 Cancel
             </button>
             <button type="submit"
                     id="modal-save-button"
-                    class="px-4 py-2 text-sm font-medium text-white border border-transparent rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 transition-colors duration-200 shadow-sm"
+                    class="px-4 py-2 text-sm font-medium text-white border border-transparent rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 shadow-sm"
                     data-initial-disabled="true"
                     hx-indicator="#save-spinner">
                 <span class="save-text">Save</span>

--- a/app/templates/macros/dropdowns.html
+++ b/app/templates/macros/dropdowns.html
@@ -123,14 +123,8 @@
     </button>
     
     <div x-show="open"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="opacity-0 scale-95"
-         x-transition:enter-end="opacity-100 scale-100"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-start="opacity-100 scale-100"
-         x-transition:leave-end="opacity-0 scale-95"
          class="dropdown-menu"
-         x-cloak>
+         x-cloak
         {% if is_single %}
             {# Single select options #}
             {% for option in options %}
@@ -272,14 +266,8 @@
     </button>
 
     <div x-show="open"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="opacity-0 scale-95"
-         x-transition:enter-end="opacity-100 scale-100"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-start="opacity-100 scale-100"
-         x-transition:leave-end="opacity-0 scale-95"
          class="dropdown-menu"
-         x-cloak>
+         x-cloak
 
         {% for option in options %}
             {%- if option is mapping -%}

--- a/app/templates/macros/modals/base/modal_base.html
+++ b/app/templates/macros/modals/base/modal_base.html
@@ -1,18 +1,18 @@
 {% from 'macros/base/icons.html' import icon %}
 {% macro base_modal(modal_id, show_var="show", backdrop_click_close=true) %}
 <div id="{{ modal_id }}"
-     class="fixed inset-0 z-50 overflow-y-auto hidden transition-opacity duration-300 ease-in-out"
+     class="fixed inset-0 z-50 overflow-y-auto hidden"
      aria-labelledby="{{ modal_id }}-title"
      role="dialog"
      aria-modal="true">
 
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        <div class="fixed inset-0 bg-black bg-opacity-50"
              {% if not backdrop_click_close %}data-closable="false"{% endif %}></div>
 
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
 
-        <div class="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full sm:p-6"
+        <div class="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full sm:p-6"
              data-stop-propagation>
             {{ caller() }}
         </div>
@@ -26,7 +26,7 @@
     <h3 class="text-xl font-semibold text-gray-900" id="modal-title">
         {{ title }}
     </h3>
-    <button class="text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full p-2 transition-colors duration-200">
+    <button class="text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full p-2">
         {{ icon('x-mark', 'lg') }}
     </button>
 </div>
@@ -34,11 +34,11 @@
 
 {% macro modal_footer(show_var="show", save_action="", save_text="Save", save_loading_var="saving") %}
 <div class="bg-gray-50 px-6 py-4 border-t border-gray-200 rounded-b-lg flex justify-end space-x-3">
-    <button class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:border-gray-400 transition-colors duration-200 shadow-sm">
+    <button class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:border-gray-400 shadow-sm">
         Cancel
     </button>
     {% if save_action %}
-    <button data-action="modal-save" data-save-handler="{{ save_action }}" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-blue-600 rounded-md hover:bg-blue-700 transition-colors duration-200 shadow-sm">
+    <button data-action="modal-save" data-save-handler="{{ save_action }}" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-blue-600 rounded-md hover:bg-blue-700 shadow-sm">
         <span class="save-text">{{ save_text }}</span>
         <span class="save-loading hidden">
             {{ icon('spinner', 'sm', 'animate-spin -ml-1 mr-2 text-white') }}


### PR DESCRIPTION
## Summary
- Removed all animation delays from modals and dropdowns for instant, snappy interactions
- Disabled autocomplete text suggestions in entity linker
- Maintained consistent dropdown styling throughout the app

## Changes
- **Modal animations removed**: No more fade/slide transitions (300ms delays eliminated)
- **Close button animations removed**: Instant hover state changes
- **Dropdown transitions removed**: Menus appear instantly without scale/opacity animations
- **Entity linker suggestions disabled**: No more autocomplete dropdown while typing
- **Chat widget animations removed**: Removed bounce effects and transitions
- **CSS keyframes deleted**: Removed unused animation definitions

## Test Plan
- [ ] Open any modal - should appear instantly
- [ ] Close modals - should disappear instantly
- [ ] Test dropdowns - should open/close instantly
- [ ] Verify dropdown styling remains consistent
- [ ] Entity linker no longer shows suggestions while typing
- [ ] Chat widget opens/closes without animation