### PR TITLE
Fix badge display to show text without hyphens

### DIFF
--- a/app/models/opportunity.py
+++ b/app/models/opportunity.py
@@ -499,40 +499,48 @@ class Opportunity(EntityModel):
     def to_display_dict(self) -> Dict[str, Any]:
         """
         Convert opportunity to dictionary with pre-formatted display fields.
-        
+
         Extends the basic dictionary representation with formatted
         fields optimized for display in user interfaces. This includes
         formatted currency values, percentages, and other UI-specific formatting.
-        
+
         Returns:
             Dictionary with all standard fields plus display-formatted versions
             of fields that benefit from special formatting:
             - value_formatted: Currency formatted deal value
             - probability_formatted: Percentage formatted probability
             - deal_age_formatted: Human-readable deal age
-            
+            - stage_display: Human-readable stage (e.g., "Closed Won" instead of "closed-won")
+            - priority_display: Human-readable priority
+
         Example:
-            >>> opp = Opportunity(value=50000, probability=75)
+            >>> opp = Opportunity(value=50000, probability=75, stage="closed-won")
             >>> display_data = opp.to_display_dict()
             >>> print(display_data['value_formatted'])
             '$50,000'
             >>> print(display_data['probability_formatted'])
             '75%'
+            >>> print(display_data['stage_display'])
+            'Closed Won'
         """
         from app.utils.ui.formatters import create_display_dict, DisplayFormatter
-        
+
         # Get base dictionary
         result = self.to_dict()
-        
+
         # Add formatted display fields at source
         display_fields = create_display_dict(self)
         result.update(display_fields)
-        
+
         # Add opportunity-specific formatted fields
         result['value_formatted'] = DisplayFormatter.format_currency(self.value)
         result['probability_formatted'] = DisplayFormatter.format_percentage(self.probability / 100.0 if self.probability else 0)
         result['deal_age_formatted'] = f"{self.deal_age} days old"
-        
+
+        # Add display-friendly versions of choice fields
+        result['stage_display'] = self.stage.replace('-', ' ').replace('_', ' ').title() if self.stage else ''
+        result['priority_display'] = self.priority.replace('-', ' ').replace('_', ' ').title() if self.priority else ''
+
         return result
 
     def __repr__(self) -> str:

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -464,36 +464,50 @@ class Task(EntityModel):
     def to_display_dict(self) -> Dict[str, Any]:
         """
         Convert task to dictionary with pre-formatted display fields.
-        
+
         Extends the basic dictionary representation with formatted
         fields optimized for display in user interfaces. This includes
         formatted currency values for linked opportunities and other
         UI-specific formatting.
-        
+
         Returns:
             Dictionary with all standard fields plus display-formatted versions
-            of fields that benefit from special formatting.
-            
+            of fields that benefit from special formatting:
+            - status_display: Human-readable status (e.g., "In Progress" instead of "in-progress")
+            - priority_display: Human-readable priority
+            - next_step_type_display: Human-readable next step type
+            - task_type_display: Human-readable task type
+            - dependency_type_display: Human-readable dependency type
+
         Example:
-            >>> task = Task(description="Big deal follow-up")
+            >>> task = Task(description="Big deal follow-up", status="in-progress")
             >>> display_data = task.to_display_dict()
             >>> print(display_data.get('opportunity_value_formatted'))
             '$50,000'
+            >>> print(display_data['status_display'])
+            'In Progress'
         """
         from app.utils.ui.formatters import create_display_dict
-        
+
         # Get base dictionary
         result = self.to_dict()
-        
+
         # Add formatted display fields at source
         display_fields = create_display_dict(self)
         result.update(display_fields)
-        
+
         # Add task-specific formatted fields
         if self.opportunity_value:
             from app.utils.ui.formatters import DisplayFormatter
             result['opportunity_value_formatted'] = DisplayFormatter.format_currency(self.opportunity_value)
-        
+
+        # Add display-friendly versions of choice fields
+        result['status_display'] = self.status.replace('-', ' ').replace('_', ' ').title() if self.status else ''
+        result['priority_display'] = self.priority.replace('-', ' ').replace('_', ' ').title() if self.priority else ''
+        result['next_step_type_display'] = self.next_step_type.replace('-', ' ').replace('_', ' ').title() if self.next_step_type else ''
+        result['task_type_display'] = self.task_type.replace('-', ' ').replace('_', ' ').title() if self.task_type else ''
+        result['dependency_type_display'] = self.dependency_type.replace('-', ' ').replace('_', ' ').title() if self.dependency_type else ''
+
         return result
 
     def __repr__(self) -> str:

--- a/app/templates/macros/ui/badges.html
+++ b/app/templates/macros/ui/badges.html
@@ -12,13 +12,13 @@
 {% endmacro %}
 
 {# Universal badge macro following ADR-011 dynamic class pattern #}
-{% macro universal_badge(value, badge_type='status', entity_type=None, size='md', additional_classes='') -%}
+{% macro universal_badge(value, badge_type='status', entity_type=None, size='md', additional_classes='', display_text=None) -%}
 {%- set norm = normalize_badge_value(value) -%}
 {%- if norm.normalized in ['high', 'medium', 'low'] and badge_type == 'status' -%}
   {%- set badge_type = 'priority' -%}
 {%- endif -%}
 <span class="badge badge-{{ badge_type }}-{{ norm.normalized }}{% if entity_type %} badge-entity-{{ entity_type|lower }}{% endif %} {{ additional_classes }}">
-  {{ norm.display }}
+  {{ display_text if display_text else norm.display }}
 </span>
 {%- endmacro %}
 

--- a/app/templates/macros/ui/card_items.html
+++ b/app/templates/macros/ui/card_items.html
@@ -1,5 +1,6 @@
 {# Simple card item macro for dashboard cards - DRY approach #}
 {% from 'macros/ui/date_formatting.html' import smart_date_display %}
+{% from 'macros/ui/badges.html' import universal_badge %}
 
 {% macro card_item(color='gray') %}
 <div class="p-3 bg-{{ color }}-50 rounded-lg hover:bg-{{ color }}-100 transition-colors
@@ -56,7 +57,7 @@
 {% endcall %}
 {% endmacro %}
 
-{% macro entity_card_with_badge(entity, subtitle_parts=[], badge_text=None, badge_type='status') %}
+{% macro entity_card_with_badge(entity, subtitle_parts=[], badge_text=None, badge_display=None, badge_type='status') %}
 {# Generic card with badge - can be used for opportunities, deals, or any entity with status #}
 {% call card_item('gray') %}
     <div class="flex items-start justify-between">
@@ -76,9 +77,8 @@
             {% endif %}
         </div>
         {% if badge_text %}
-        {%- set normalized_badge = badge_text|string|lower|replace(' ', '-')|replace('_', '-') -%}
-        <span class="ml-3 badge badge-{{ badge_type }}-{{ normalized_badge }}">
-            {{ badge_text|title }}
+        <span class="ml-3">
+            {{ universal_badge(badge_text, badge_type=badge_type, display_text=badge_display) }}
         </span>
         {% endif %}
     </div>
@@ -95,6 +95,7 @@
             {'text': entity.value_formatted, 'color': 'text-opportunity-value'}
         ],
         badge_text=entity.stage,
+        badge_display=entity.stage_display if entity.stage_display is defined else None,
         badge_type='status'
     ) }}
 {% elif entity_type == 'company' %}
@@ -105,6 +106,7 @@
             {'text': entity.company_size, 'color': 'text-gray-600'} if entity.company_size else {}
         ],
         badge_text=entity.status if entity.status else None,
+        badge_display=entity.status_display if entity.status_display is defined else None,
         badge_type='status'
     ) }}
 {% elif entity_type == 'stakeholder' %}
@@ -115,6 +117,7 @@
             {'text': entity.role, 'color': 'text-gray-600'} if entity.role else {}
         ],
         badge_text=entity.status if entity.status else None,
+        badge_display=entity.status_display if entity.status_display is defined else None,
         badge_type='status'
     ) }}
 {% else %}
@@ -123,6 +126,7 @@
         entity,
         subtitle_parts=[],
         badge_text=entity.status if entity.status else None,
+        badge_display=entity.status_display if entity.status_display is defined else None,
         badge_type='status'
     ) }}
 {% endif %}

--- a/app/templates/macros/ui/card_items.html
+++ b/app/templates/macros/ui/card_items.html
@@ -62,7 +62,8 @@
 {% call card_item('gray') %}
     <div class="flex items-start justify-between">
         <div class="flex-1">
-            <div class="text-card-title">{{ entity.name }}</div>
+            {%- set entity_name = entity.get('name', '') if entity is mapping else entity.name -%}
+            <div class="text-card-title">{{ entity_name }}</div>
             {% if subtitle_parts %}
             <div class="text-card-meta">
                 {% for part in subtitle_parts %}
@@ -87,15 +88,29 @@
 
 {% macro entity_card_item(entity, entity_type='opportunity') %}
 {# Generic wrapper for any entity with status badge - DRY and reusable #}
+{# Handle both dict (from to_display_dict) and object formats #}
 {% if entity_type == 'opportunity' %}
+    {%- if entity is mapping -%}
+        {# Entity is a dict from to_display_dict() #}
+        {%- set stage = entity.get('stage') or '' -%}
+        {%- set stage_display = entity.get('stage_display') or '' -%}
+        {%- set company_name = entity.get('company_name', '') -%}
+        {%- set value_formatted = entity.get('value_formatted', '') -%}
+    {%- else -%}
+        {# Entity is an object #}
+        {%- set stage = entity.stage -%}
+        {%- set stage_display = entity.stage_display if entity.stage_display is defined else None -%}
+        {%- set company_name = entity.company_name -%}
+        {%- set value_formatted = entity.value_formatted -%}
+    {%- endif -%}
     {{ entity_card_with_badge(
         entity,
         subtitle_parts=[
-            {'text': entity.company_name, 'color': 'text-company-name'},
-            {'text': entity.value_formatted, 'color': 'text-opportunity-value'}
+            {'text': company_name, 'color': 'text-company-name'},
+            {'text': value_formatted, 'color': 'text-opportunity-value'}
         ],
-        badge_text=entity.stage,
-        badge_display=entity.stage_display if entity.stage_display is defined else None,
+        badge_text=stage,
+        badge_display=stage_display,
         badge_type='status'
     ) }}
 {% elif entity_type == 'company' %}

--- a/tools/database/seed_data.py
+++ b/tools/database/seed_data.py
@@ -504,7 +504,9 @@ def create_opportunities(companies, contacts):
         # Create 1-2 opportunities per company to simplify relationships
         num_opps = random.randint(1, 2)
 
-        company_contacts = [c for c in contacts if c.company_id == company.id]
+        # Pre-fetch company ID to avoid autoflush issues
+        company_id = company.id
+        company_contacts = [c for c in contacts if c.company_id == company_id]
 
         for i in range(num_opps):
             # Generate deal value in the specified range
@@ -530,10 +532,12 @@ def create_opportunities(companies, contacts):
                 created_at=datetime.now() - timedelta(days=random.randint(1, 120)),
             )
 
-            # Associate with 1 stakeholder from the company  
+            # Associate with 1 stakeholder from the company
             if company_contacts:
                 selected_contact = random.choice(company_contacts)
-                opportunity.stakeholders.append(selected_contact)
+                # Use no_autoflush to prevent premature constraint checks
+                with db.session.no_autoflush:
+                    opportunity.stakeholders.append(selected_contact)
 
             opportunities.append(opportunity)
             db.session.add(opportunity)


### PR DESCRIPTION
## Summary
- Fixed badge display to show human-readable text without hyphens (e.g., "Closed Won" instead of "Closed-Won")
- Fixed seed script autoflush issues preventing database population
- Updated templates to handle both dictionary and object formats

## Changes Made

### Badge Display Fix
- Added `stage_display` and `priority_display` fields to `Opportunity.to_display_dict()`
- Added display fields for all choice fields in `Task.to_display_dict()`
- Updated `universal_badge` macro to accept optional display text
- Modified `card_items.html` to use centralized badge macro and pass display fields

### Seed Script Fix  
- Fixed SQLAlchemy autoflush issue by pre-fetching company IDs
- Wrapped stakeholder-opportunity associations in `no_autoflush` blocks
- Successfully populates database with 26 opportunities, 134 tasks, and 150 notes

### Template Compatibility
- Updated `entity_card_item` and `entity_card_with_badge` macros to handle both dict and object formats
- Added proper accessor patterns for dictionary values from `to_display_dict()`

## Test Results
- Database successfully seeded with test data
- Dashboard displays opportunities with properly formatted badges
- "Closed Won" and "Closed Lost" display without hyphens
- All other status/stage values format correctly

## Breaking Changes
None - backwards compatible with existing code