### PR TITLE
fix: resolve tasks page crash and modal service errors

### DIFF
--- a/app/routes/web/tasks.py
+++ b/app/routes/web/tasks.py
@@ -75,6 +75,7 @@ def index():
             'entity_description': 'Manage your tasks',
             'entity_type': 'task',
             'endpoint_name': 'tasks',
+            'content_endpoint': 'tasks.content',
             'entity_buttons': ['tasks']
         },
         'entity_stats': entity_stats,

--- a/app/utils/ui/modal_service.py
+++ b/app/utils/ui/modal_service.py
@@ -9,6 +9,11 @@ from typing import Dict, Any, Optional
 import logging
 from flask import render_template, jsonify, request
 from app.models import db
+from app.models.company import Company
+from app.models.opportunity import Opportunity
+from app.models.task import Task
+from app.models.user import User
+from app.models.stakeholder import Stakeholder
 # ModelIntrospector removed - use model methods directly
 from app.forms.entities.company import CompanyForm
 from app.forms.entities.stakeholder import StakeholderForm
@@ -18,6 +23,17 @@ from app.forms.modals.user import UserModalForm
 from app.forms.base.base_forms import BaseForm
 # No icon functions needed - templates handle CSS class generation
 
+
+def get_model_by_name(model_name: str):
+    """Get model class by string name."""
+    model_mapping = {
+        'company': Company,
+        'opportunity': Opportunity,
+        'task': Task,
+        'user': User,
+        'stakeholder': Stakeholder
+    }
+    return model_mapping.get(model_name.lower())
 
 
 class ModalService:


### PR DESCRIPTION
## Summary
- Fixed tasks page 500 error by adding missing content_endpoint to entity_config
- Implemented get_model_by_name function with proper model imports for modal service
- Resolved NameError that was breaking modal functionality

## Test plan
- [x] Tasks page loads successfully without 500 error
- [x] Modal service can resolve model names correctly
- [x] Application runs without crashes