### PR TITLE
refactor: remove modal_mode and make modals.py DRY

### DIFF
--- a/app/forms/entities/company.py
+++ b/app/forms/entities/company.py
@@ -11,21 +11,18 @@ from ..base.base_forms import BaseForm
 
 
 class CompanyForm(BaseForm):
-    """Unified form for creating and editing companies - supports both full and modal modes"""
+    """Form for creating and editing companies in modals"""
 
-    def __init__(self, *args, modal_mode=False, **kwargs):
-        self.modal_mode = modal_mode
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Set industry choices from model metadata
+        # Set choices from model metadata
         from app.models.company import Company
         industry_choices = Company.get_field_choices('industry')
         self.industry.choices = [('', 'Select industry')] + industry_choices
 
-        if not modal_mode:
-            # Only set size choices for full forms
-            size_choices = Company.get_field_choices('size')
-            self.size.choices = [('', 'Select size')] + size_choices
+        size_choices = Company.get_field_choices('size')
+        self.size.choices = [('', 'Select size')] + size_choices
 
     name = StringField(
         'Company Name',
@@ -66,10 +63,6 @@ class CompanyForm(BaseForm):
         render_kw={'rows': 3}
     )
 
-    def get_modal_fields(self):
-        """Return field names to display in modal mode"""
+    def get_fields(self):
+        """Return field names to display in modal"""
         return ['name', 'industry', 'comments']
-
-    def get_full_fields(self):
-        """Return field names to display in full form mode"""
-        return ['name', 'industry', 'website', 'size', 'phone', 'address']

--- a/app/forms/entities/opportunity.py
+++ b/app/forms/entities/opportunity.py
@@ -12,24 +12,22 @@ from app.utils.forms.helpers import safe_int_coerce
 
 
 class OpportunityForm(BaseForm):
-    """Unified form for creating and editing opportunities - supports both full and modal modes"""
+    """Form for creating and editing opportunities in modals"""
 
-    def __init__(self, *args, modal_mode=False, **kwargs):
-        self.modal_mode = modal_mode
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Set choices from model metadata
         from app.models.opportunity import Opportunity
 
-        if not modal_mode:
-            # Only set priority choices for full forms
-            priority_choices = Opportunity.get_field_choices('priority')
-            self.priority.choices = [('', 'Select priority')] + priority_choices
+        # Set priority choices
+        priority_choices = Opportunity.get_field_choices('priority')
+        self.priority.choices = [('', 'Select priority')] + priority_choices
 
-        # Set stage choices (needed for both modal and full forms)
+        # Set stage choices
         stage_choices = Opportunity.get_field_choices('stage')
         self.stage.choices = [('', 'Select stage')] + stage_choices
 
-        # Set company choices (needed for both modal and full forms)
+        # Set company choices
         from app.models.company import Company
         companies = Company.query.order_by(Company.name).all()
         self.company_id.choices = [('', 'Select company')] + [
@@ -81,10 +79,6 @@ class OpportunityForm(BaseForm):
         coerce=safe_int_coerce
     )
 
-    def get_modal_fields(self):
-        """Return field names to display in modal mode"""
+    def get_fields(self):
+        """Return field names to display in modal"""
         return ['name', 'company_id', 'value', 'stage']
-
-    def get_full_fields(self):
-        """Return field names to display in full form mode"""
-        return ['name', 'value', 'probability', 'priority', 'expected_close_date', 'stage', 'company_id']

--- a/app/forms/entities/stakeholder.py
+++ b/app/forms/entities/stakeholder.py
@@ -12,20 +12,18 @@ from app.utils.forms.helpers import safe_int_coerce
 
 
 class StakeholderForm(BaseForm):
-    """Unified form for creating and editing stakeholders - supports both full and modal modes"""
+    """Form for creating and editing stakeholders in modals"""
 
-    def __init__(self, *args, modal_mode=False, **kwargs):
-        self.modal_mode = modal_mode
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Set choices from model metadata
         from app.models.stakeholder import Stakeholder
 
-        if not modal_mode:
-            # Only set MEDDPICC choices for full forms
-            meddpicc_choices = Stakeholder.get_field_choices('meddpicc_role')
-            self.meddpicc_role.choices = [('', 'Select MEDDPICC role')] + meddpicc_choices
+        # Set MEDDPICC choices
+        meddpicc_choices = Stakeholder.get_field_choices('meddpicc_role')
+        self.meddpicc_role.choices = [('', 'Select MEDDPICC role')] + meddpicc_choices
 
-        # Set company choices (needed for both modal and full forms)
+        # Set company choices
         from app.models.company import Company
         companies = Company.query.order_by(Company.name).all()
         self.company_id.choices = [('', 'Select company')] + [
@@ -69,10 +67,6 @@ class StakeholderForm(BaseForm):
         coerce=safe_int_coerce
     )
 
-    def get_modal_fields(self):
-        """Return field names to display in modal mode"""
+    def get_fields(self):
+        """Return field names to display in modal"""
         return ['name', 'email', 'company_id']
-
-    def get_full_fields(self):
-        """Return field names to display in full form mode"""
-        return ['name', 'job_title', 'email', 'phone', 'meddpicc_role', 'company_id']

--- a/app/routes/web/modals.py
+++ b/app/routes/web/modals.py
@@ -1,10 +1,10 @@
 """
-Generic Modal Routes for HTMX-based Forms
+Generic Modal Routes for HTMX-based Forms - DRY Refactored
 
-Direct, simple modal handling without unnecessary abstraction layers.
+Clean, maintainable modal handling with zero duplication.
 """
 
-from flask import Blueprint, request, render_template, jsonify
+from flask import Blueprint, request, render_template
 from app.models import db, MODEL_REGISTRY
 from app.forms.entities.company import CompanyForm
 from app.forms.entities.stakeholder import StakeholderForm
@@ -23,209 +23,151 @@ FORM_REGISTRY = {
     'user': UserModalForm
 }
 
-# Models that require modal_mode parameter
-MODAL_MODE_MODELS = {'company', 'stakeholder', 'opportunity'}
 
+# ============= HELPER FUNCTIONS =============
+
+def _validate_model_and_form(model_name):
+    """Validate model and form exist, return components or error."""
+    model_class = MODEL_REGISTRY.get(model_name.lower())
+    if not model_class:
+        return None, None, render_template('components/modals/error_modal.html',
+                                          error=f"Unknown model: {model_name}")
+
+    form_class = FORM_REGISTRY.get(model_name.lower())
+    if not form_class:
+        return None, None, render_template('components/modals/error_modal.html',
+                                          error=f"No form available for {model_name}")
+
+    return model_class, form_class, None
+
+
+def _render_modal(model_name, model_class, form, mode='create', entity=None, error=None):
+    """Render modal template with appropriate parameters."""
+    # Base parameters - always present
+    params = {
+        'model_name': model_name,
+        'model_class': model_class,
+        'form': form,
+        'modal_title': f'{mode.title()} {model_name}'
+    }
+
+    # Mode-specific parameters
+    if mode == 'view':
+        params.update({
+            'mode': 'view',
+            'is_view': True,
+            'entity': entity,
+            'entity_id': entity.id if entity else None
+        })
+    elif mode == 'edit':
+        params.update({
+            'entity': entity,
+            'entity_id': entity.id,
+            'action_url': f'/modals/{model_name}/{entity.id}/update',
+            'is_edit': True
+        })
+    else:  # create
+        params.update({
+            'action_url': f'/modals/{model_name}/create',
+            'is_edit': False
+        })
+
+    if error:
+        params['error'] = error
+
+    return render_template('components/modals/wtforms_modal.html', **params)
+
+
+def _handle_form_submission(model_name, model_class, form, entity=None):
+    """Handle form submission for both create and update operations."""
+    if form.validate_on_submit():
+        try:
+            if entity is None:
+                # Create new entity
+                entity = model_class()
+                form.populate_obj(entity)
+                db.session.add(entity)
+                action = "created"
+            else:
+                # Update existing entity
+                form.populate_obj(entity)
+                action = "updated"
+
+            db.session.commit()
+            return render_template('components/modals/form_success.html',
+                                 message=f"{model_name} {action} successfully",
+                                 entity=entity)
+        except Exception as e:
+            db.session.rollback()
+            mode = 'edit' if entity else 'create'
+            return _render_modal(model_name, model_class, form,
+                               mode=mode, entity=entity, error=str(e))
+
+    # Form validation failed - re-render with errors
+    mode = 'edit' if entity else 'create'
+    return _render_modal(model_name, model_class, form, mode=mode, entity=entity)
+
+
+# ============= ROUTE HANDLERS =============
 
 @modals_bp.route('/<model_name>/create')
 def create_modal(model_name):
     """Render create modal for any model."""
-    model_class = MODEL_REGISTRY.get(model_name.lower())
-    if not model_class:
-        return render_template('components/modals/error_modal.html',
-                             error=f"Unknown model: {model_name}")
+    model_class, form_class, error = _validate_model_and_form(model_name)
+    if error:
+        return error
 
-    form_class = FORM_REGISTRY.get(model_name.lower())
-    if not form_class:
-        return render_template('components/modals/error_modal.html',
-                             error=f"No form available for {model_name}")
-
-    # Create form with modal_mode if needed
-    if model_name.lower() in MODAL_MODE_MODELS:
-        form = form_class(modal_mode=True)
-    else:
-        form = form_class()
-
-    return render_template('components/modals/wtforms_modal.html',
-                         model_name=model_name,
-                         model_class=model_class,
-                         form=form,
-                         action_url=f'/modals/{model_name}/create',
-                         modal_title=f'Create {model_name}',
-                         is_edit=False)
+    form = form_class()
+    return _render_modal(model_name, model_class, form, mode='create')
 
 
 @modals_bp.route('/<model_name>/<int:entity_id>/edit')
 def edit_modal(model_name, entity_id):
     """Render edit modal for any model and entity."""
-    model_class = MODEL_REGISTRY.get(model_name.lower())
-    if not model_class:
-        return render_template('components/modals/error_modal.html',
-                             error=f"Unknown model: {model_name}")
+    model_class, form_class, error = _validate_model_and_form(model_name)
+    if error:
+        return error
 
     entity = model_class.query.get_or_404(entity_id)
-
-    form_class = FORM_REGISTRY.get(model_name.lower())
-    if not form_class:
-        return render_template('components/modals/error_modal.html',
-                             error=f"No form available for {model_name}")
-
-    # Create form with entity and modal_mode if needed
-    if model_name.lower() in MODAL_MODE_MODELS:
-        form = form_class(obj=entity, modal_mode=True)
-    else:
-        form = form_class(obj=entity)
-
-    return render_template('components/modals/wtforms_modal.html',
-                         model_name=model_name,
-                         model_class=model_class,
-                         entity=entity,
-                         entity_id=entity_id,
-                         form=form,
-                         action_url=f'/modals/{model_name}/{entity_id}/update',
-                         modal_title=f'Edit {model_name}',
-                         is_edit=True)
+    form = form_class(obj=entity)
+    return _render_modal(model_name, model_class, form, mode='edit', entity=entity)
 
 
 @modals_bp.route('/<model_name>/<int:entity_id>/view')
 def view_modal(model_name, entity_id):
     """Render read-only view modal for any model and entity."""
-    model_class = MODEL_REGISTRY.get(model_name.lower())
-    if not model_class:
-        return render_template('components/modals/error_modal.html',
-                             error=f"Unknown model: {model_name}")
+    model_class, form_class, error = _validate_model_and_form(model_name)
+    if error:
+        return error
 
     entity = model_class.query.get_or_404(entity_id)
-
-    form_class = FORM_REGISTRY.get(model_name.lower())
-    if not form_class:
-        return render_template('components/modals/error_modal.html',
-                             error=f"No form available for {model_name}")
-
-    # Create form for viewing
-    if model_name.lower() in MODAL_MODE_MODELS:
-        form = form_class(obj=entity, modal_mode=True)
-    else:
-        form = form_class(obj=entity)
-
-    return render_template('components/modals/wtforms_modal.html',
-                         model_name=model_name,
-                         model_class=model_class,
-                         entity=entity,
-                         entity_id=entity_id,
-                         form=form,
-                         modal_title=f'View {model_name}',
-                         mode='view',
-                         is_edit=False,
-                         is_view=True)
+    form = form_class(obj=entity)
+    return _render_modal(model_name, model_class, form, mode='view', entity=entity)
 
 
 @modals_bp.route('/<model_name>/create', methods=['POST'])
 def create_entity(model_name):
     """Handle form submission for creating new entity."""
-    model_class = MODEL_REGISTRY.get(model_name.lower())
-    if not model_class:
+    model_class, form_class, error = _validate_model_and_form(model_name)
+    if error:
         return render_template('components/modals/form_error.html',
-                             error=f"Unknown model: {model_name}")
+                             error=error.get_data(as_text=True))
 
-    form_class = FORM_REGISTRY.get(model_name.lower())
-    if not form_class:
-        return render_template('components/modals/form_error.html',
-                             error=f"No form available for {model_name}")
-
-    # Create and validate form
-    if model_name.lower() in MODAL_MODE_MODELS:
-        form = form_class(modal_mode=True)
-    else:
-        form = form_class()
-
-    if form.validate_on_submit():
-        try:
-            # Create new entity from form data
-            entity = model_class()
-            form.populate_obj(entity)
-            db.session.add(entity)
-            db.session.commit()
-
-            return render_template('components/modals/form_success.html',
-                                 message=f"{model_name} created successfully",
-                                 entity=entity)
-        except Exception as e:
-            db.session.rollback()
-            # Re-render form with error
-            return render_template('components/modals/wtforms_modal.html',
-                                 model_name=model_name,
-                                 model_class=model_class,
-                                 form=form,
-                                 action_url=f'/modals/{model_name}/create',
-                                 modal_title=f'Create {model_name}',
-                                 is_edit=False,
-                                 error=str(e))
-
-    # Form validation failed - re-render with errors
-    return render_template('components/modals/wtforms_modal.html',
-                         model_name=model_name,
-                         model_class=model_class,
-                         form=form,
-                         action_url=f'/modals/{model_name}/create',
-                         modal_title=f'Create {model_name}',
-                         is_edit=False)
+    form = form_class()
+    return _handle_form_submission(model_name, model_class, form)
 
 
 @modals_bp.route('/<model_name>/<int:entity_id>/update', methods=['POST'])
 def update_entity(model_name, entity_id):
     """Handle form submission for updating existing entity."""
-    model_class = MODEL_REGISTRY.get(model_name.lower())
-    if not model_class:
+    model_class, form_class, error = _validate_model_and_form(model_name)
+    if error:
         return render_template('components/modals/form_error.html',
-                             error=f"Unknown model: {model_name}")
+                             error=error.get_data(as_text=True))
 
     entity = model_class.query.get_or_404(entity_id)
-
-    form_class = FORM_REGISTRY.get(model_name.lower())
-    if not form_class:
-        return render_template('components/modals/form_error.html',
-                             error=f"No form available for {model_name}")
-
-    # Create and validate form
-    if model_name.lower() in MODAL_MODE_MODELS:
-        form = form_class(obj=entity, modal_mode=True)
-    else:
-        form = form_class(obj=entity)
-
-    if form.validate_on_submit():
-        try:
-            # Update entity from form data
-            form.populate_obj(entity)
-            db.session.commit()
-
-            return render_template('components/modals/form_success.html',
-                                 message=f"{model_name} updated successfully",
-                                 entity=entity)
-        except Exception as e:
-            db.session.rollback()
-            # Re-render form with error
-            return render_template('components/modals/wtforms_modal.html',
-                                 model_name=model_name,
-                                 model_class=model_class,
-                                 entity=entity,
-                                 entity_id=entity_id,
-                                 form=form,
-                                 action_url=f'/modals/{model_name}/{entity_id}/update',
-                                 modal_title=f'Edit {model_name}',
-                                 is_edit=True,
-                                 error=str(e))
-
-    # Form validation failed - re-render with errors
-    return render_template('components/modals/wtforms_modal.html',
-                         model_name=model_name,
-                         model_class=model_class,
-                         entity=entity,
-                         entity_id=entity_id,
-                         form=form,
-                         action_url=f'/modals/{model_name}/{entity_id}/update',
-                         modal_title=f'Edit {model_name}',
-                         is_edit=True)
+    form = form_class(obj=entity)
+    return _handle_form_submission(model_name, model_class, form, entity=entity)
 
 
 @modals_bp.route('/close')

--- a/app/templates/macros/modals/field_filter.html
+++ b/app/templates/macros/modals/field_filter.html
@@ -7,8 +7,8 @@ Single source of truth for determining which fields to display
   {# Direct field rendering without caller mechanism #}
   {% from 'macros/modals/universal_field.html' import render_universal_field %}
 
-  {% if form.modal_mode and hasattr(form, 'get_modal_fields') %}
-    {% set allowed_fields = form.get_modal_fields() %}
+  {% if hasattr(form, 'get_fields') %}
+    {% set allowed_fields = form.get_fields() %}
   {% else %}
     {% set allowed_fields = form|selectattr('name', 'ne', 'csrf_token')|selectattr('name', 'ne', 'submit')|map(attribute='name')|list %}
   {% endif %}


### PR DESCRIPTION
## Summary
- Remove confusing modal_mode parameter from all form classes
- Refactor modals.py with helper functions to eliminate duplication
- Reduce codebase by ~100 lines while improving maintainability

## Changes
- **Forms simplified**: Removed modal_mode parameter, dead get_full_fields() methods
- **modals.py refactored**: Reduced from 234 to 176 lines with zero repetition
- **Technical debt eliminated**: Forms are now single-purpose (modal-only)
- **Template updated**: field_filter.html now uses simplified get_fields() method

## Test Plan
- [ ] Test creating new Company via modal
- [ ] Test editing existing Stakeholder via modal  
- [ ] Test viewing Opportunity in read-only modal
- [ ] Test form validation errors display correctly
- [ ] Verify all modal forms show correct fields