### PR TITLE
Remove email field from stakeholder creation modal

### DIFF
--- a/app/forms/entities/stakeholder.py
+++ b/app/forms/entities/stakeholder.py
@@ -69,4 +69,4 @@ class StakeholderForm(BaseForm):
 
     def get_fields(self):
         """Return field names to display in modal"""
-        return ['name', 'email', 'company_id']
+        return ['name', 'company_id']

--- a/app/templates/macros/base/forms.html
+++ b/app/templates/macros/base/forms.html
@@ -280,10 +280,10 @@
             <!-- Add HTMX validation for unique fields -->
             {% set needs_validation = false %}
             {% set entity_type = "" %}
-            {% if field.form.__class__.__name__ == 'CompanyModalForm' and field.name == 'name' %}
+            {% if field.form.__class__.__name__ == 'CompanyForm' and field.name == 'name' %}
                 {% set needs_validation = true %}
                 {% set entity_type = "company" %}
-            {% elif field.form.__class__.__name__ == 'StakeholderModalForm' and field.name == 'email' %}
+            {% elif field.form.__class__.__name__ == 'StakeholderForm' and field.name == 'name' %}
                 {% set needs_validation = true %}
                 {% set entity_type = "stakeholder" %}
             {% endif %}


### PR DESCRIPTION
## Summary
- Removed email field from the stakeholder creation modal to simplify the form
- Fixed form class name validation checks to match actual class names
- Made the solution DRY by using existing field filtering mechanism

## Changes
1. **Stakeholder form field filtering** - Removed 'email' from `get_fields()` method to exclude it from modal display
2. **Fixed validation class names** - Updated template to use correct form class names (`CompanyForm`/`StakeholderForm` instead of `CompanyModalForm`/`StakeholderModalForm`)
3. **Updated stakeholder validation** - Changed to validate on 'name' field instead of removed 'email' field

## Test Plan
- [ ] Create a new stakeholder - verify email field is not displayed
- [ ] Verify name field validation works for stakeholders
- [ ] Verify company name validation still works
- [ ] Test that stakeholder creation succeeds with just name and company