### PR TITLE
Fix: Unify entity search dropdowns with global search (DRY)

### DIFF
--- a/app/static/js/features/search-widget.js
+++ b/app/static/js/features/search-widget.js
@@ -19,10 +19,8 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function initializeSearchWidgets() {
-    // Find all search inputs (both global and entity search)
-    const searchInputs = document.querySelectorAll(
-        '#global-search, .search-widget-input'
-    );
+    // Find all search inputs - now unified with .search-input class
+    const searchInputs = document.querySelectorAll('.search-input');
 
     searchInputs.forEach(input => {
         // Skip if already initialized
@@ -62,16 +60,10 @@ function initializeSearchWidgets() {
     document.addEventListener('click', function(event) {
         // Close all search dropdowns when clicking outside
         document.querySelectorAll('.search-results').forEach(resultsDiv => {
-            const widget = resultsDiv.closest('.entity-search-widget');
-            const globalSearch = document.getElementById('global-search');
+            const container = resultsDiv.closest('.search-container');
 
-            // Check if click is outside this widget
-            if (widget && !widget.contains(event.target)) {
-                resultsDiv.classList.add('hidden');
-            }
-            // Check if click is outside global search
-            else if (globalSearch && !globalSearch.contains(event.target) &&
-                     !resultsDiv.contains(event.target)) {
+            // Check if click is outside the search container
+            if (container && !container.contains(event.target)) {
                 resultsDiv.classList.add('hidden');
             }
         });
@@ -83,13 +75,10 @@ function initializeSearchWidgets() {
             document.querySelectorAll('.search-results:not(.hidden)').forEach(resultsDiv => {
                 resultsDiv.classList.add('hidden');
                 // Blur the associated input
-                const widget = resultsDiv.closest('.entity-search-widget');
-                if (widget) {
-                    const input = widget.querySelector('.search-widget-input');
+                const container = resultsDiv.closest('.search-container');
+                if (container) {
+                    const input = container.querySelector('.search-input');
                     if (input) input.blur();
-                } else {
-                    const globalSearch = document.getElementById('global-search');
-                    if (globalSearch) globalSearch.blur();
                 }
             });
         }
@@ -135,7 +124,11 @@ window.selectEntity = function(fieldId, entityId, entityName, entityType) {
     createEntityBadge(fieldId, entityId, entityName, entityType);
 
     // Clear search and hide results
-    if (searchField) searchField.value = '';
+    if (searchField) {
+        searchField.value = '';
+        // Trigger input event to ensure HTMX clears results
+        searchField.dispatchEvent(new Event('input', { bubbles: true }));
+    }
     if (resultsDiv) resultsDiv.classList.add('hidden');
 };
 
@@ -199,9 +192,9 @@ window.removeEntityBadge = function(fieldId, entityId, entityType) {
 
 // Initialize any existing entity data on page load
 document.addEventListener('DOMContentLoaded', function() {
-    const widgets = document.querySelectorAll('.entity-search-widget');
-    widgets.forEach(widget => {
-        const fieldId = widget.dataset.fieldId;
+    const searchContainers = document.querySelectorAll('.search-container[data-field-id]');
+    searchContainers.forEach(container => {
+        const fieldId = container.dataset.fieldId;
         const dataField = document.getElementById(fieldId + '-data');
         const badgesDiv = document.getElementById(fieldId + '-badges');
 
@@ -218,5 +211,4 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 
-// Export for module usage if needed
-export { initializeSearchWidgets };
+// Function is available globally via window object

--- a/app/templates/macros/widgets/search.html
+++ b/app/templates/macros/widgets/search.html
@@ -20,26 +20,28 @@
     {% set placeholder = 'Search for ' + entity_type + '...' %}
 {% endif %}
 
-<div class="relative entity-search-widget" data-field-id="{{ field.id }}" data-entity-type="{{ entity_type }}">
+<div class="search-container relative" data-field-id="{{ field.id }}" data-entity-type="{{ entity_type }}">
     {# Badge display area for selected entities #}
     <div id="{{ field.id }}-badges" class="mb-2 flex flex-wrap gap-2"></div>
 
     {# Hidden field to store JSON array of selected entities #}
     <input type="hidden" id="{{ field.id }}-data" name="{{ field.name }}" value="{{ field.data or '[]' }}">
 
-    {# Search input with dynamically generated placeholder #}
-    <input type="text"
-           id="{{ field.id }}"
-           name="q"
-           placeholder="{{ placeholder }}"
-           class="form-input search-widget-input"
-           autocomplete="off"
-           hx-get="{{ url_for('search.htmx_search') }}"
-           hx-trigger="input changed delay:300ms, focus"
-           hx-target="#{{ field.id }}-results"
-           hx-vals='{"mode": "select", "field_id": "{{ field.id }}", "type": "{{ entity_type }}"}'>
+    <div class="relative">
+        {# Search input with dynamically generated placeholder - using same structure as global search #}
+        <input type="text"
+               id="{{ field.id }}"
+               name="q"
+               placeholder="{{ placeholder }}"
+               class="search-input"
+               autocomplete="off"
+               hx-get="{{ url_for('search.htmx_search') }}"
+               hx-trigger="input changed delay:300ms, focus"
+               hx-target="#{{ field.id }}-results"
+               hx-vals='{"mode": "select", "field_id": "{{ field.id }}", "type": "{{ entity_type }}"}'>
+    </div>
 
-    <div id="{{ field.id }}-results" class="search-results hidden absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md border border-gray-200 max-h-60 overflow-auto">
+    <div id="{{ field.id }}-results" class="search-results hidden">
     </div>
 </div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- Fixed broken entity search dropdowns in New Task and New Opportunity modals
- Unified all search dropdowns to use the same component (DRY principle)
- Eliminated duplicate code and inconsistent behavior

## Changes
- **JavaScript fix**: Removed export statement causing "Unexpected token" error
- **CSS unification**: All dropdowns now use `search-container` and `search-input` classes
- **Consistent styling**: Entity search dropdowns now look exactly like global search
- **Proper UX**: Dropdowns hide correctly after selection, badges work properly

## Test Plan
- [x] Test global search dropdown works
- [x] Test New Task entity search dropdown
- [x] Test New Opportunity company search dropdown
- [x] Verify selections create badges
- [x] Verify dropdowns close after selection
- [x] No JavaScript errors in console

## Before
- Entity search dropdowns were broken with HTMX target errors
- Different styling than global search
- JavaScript export error in console
- Poor UX with dropdowns not closing

## After
- All dropdowns work consistently
- Same look and behavior everywhere
- Clean console, no errors
- True DRY implementation - one component used everywhere