### PR TITLE
Fix: Unify search dropdown rendering across all modals

### DIFF
--- a/app/routes/web/search.py
+++ b/app/routes/web/search.py
@@ -118,7 +118,9 @@ def htmx_search():
     results = []
     for model in models_to_search:
         try:
-            entities = model.search(query, limit)
+            # Use empty string for initial results when no query
+            search_query = query if query else ""
+            entities = model.search(search_query, limit)
             results.extend([e.to_search_result() for e in entities])
         except Exception:
             continue

--- a/app/templates/components/search_results.html
+++ b/app/templates/components/search_results.html
@@ -24,7 +24,7 @@
            {% if mode == 'select' %}
            onclick="selectEntity('{{ field_id }}', '{{ result.id }}', '{{ result.title }}', '{{ result.type }}'); return false;"
            {% else %}
-           hx-get="{{ url_for('modals.view_modal', model_name=result.model_type, entity_id=result.id) }}"
+           hx-get="{{ url_for('modals.view_modal', model_name=result.type, entity_id=result.id) }}"
            hx-target="body"
            hx-swap="beforeend"
            {% endif %}

--- a/app/templates/macros/modals/field_filter.html
+++ b/app/templates/macros/modals/field_filter.html
@@ -42,14 +42,14 @@ Handles field filtering, view/form modes, and special field types (entity search
           {# Field name matches an entity type - it's an entity search field! #}
           <label class="block text-sm font-medium text-gray-700">{{ field.label.text }}</label>
           {{ search_widget(field, entity_type=field.name) }}
-        {% elif field.render_kw and 'Search' in field.render_kw.get('placeholder', '') %}
-          {# Search field - use search widget (entity, company, etc.) #}
-          <label class="block text-sm font-medium text-gray-700">{{ field.label.text }}</label>
-          {{ search_widget(field, entity_type=field.name) }}
         {% elif field.name == 'entity' %}
           {# General entity search field - searches all entity types #}
           <label class="block text-sm font-medium text-gray-700">{{ field.label.text }}</label>
           {{ search_widget(field, entity_type='all') }}
+        {% elif field.render_kw and 'Search' in field.render_kw.get('placeholder', '') %}
+          {# Search field - use search widget (entity, company, etc.) #}
+          <label class="block text-sm font-medium text-gray-700">{{ field.label.text }}</label>
+          {{ search_widget(field, entity_type=field.name) }}
         {% else %}
           {# Regular form field #}
           {{ render_wtforms_field(field, fast_select=true, model_name=model_name) }}

--- a/app/templates/macros/widgets/search.html
+++ b/app/templates/macros/widgets/search.html
@@ -39,9 +39,9 @@
                hx-trigger="input changed delay:300ms, focus"
                hx-target="#{{ field.id }}-results"
                hx-vals='{"mode": "select", "field_id": "{{ field.id }}", "type": "{{ entity_type }}"}'>
-    </div>
 
-    <div id="{{ field.id }}-results" class="search-results hidden">
+        <div id="{{ field.id }}-results" class="search-results hidden">
+        </div>
     </div>
 </div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- Fixed global search modal 404 error when clicking results
- Fixed Task modal's Related To field to show immediate results on focus
- Fixed dropdown positioning to render below input instead of inline
- Maintained DRY architecture with single template fix

## Problem
1. Global search was throwing 404 errors due to incorrect template variable
2. Task modal showed "Start typing to search..." instead of immediate results
3. Dropdowns appeared inline (next to input) instead of below due to CSS flexbox conflict

## Solution
- Corrected template condition order in field_filter.html (specific checks before generic)
- Fixed search_results.html to use correct variable (result.type)
- Moved search-results div inside relative container to fix positioning
- Modified search endpoint to return results with empty query

## Test Plan
- [x] Global search shows results on focus and opens modals correctly
- [x] Task modal Related To field shows all entities immediately
- [x] Opportunity modal Company field shows companies immediately
- [x] All dropdowns render as proper overlays below input fields
- [x] Single widget template change fixes all search fields (DRY)