### PR TITLE
fix: remove unused confirmation modal from entity_index template

### DIFF
--- a/app/templates/base/entity_index.html
+++ b/app/templates/base/entity_index.html
@@ -69,5 +69,5 @@
 {% endblock %}
 
 {% block modals %}
-{{ confirmation_modal((entity_config.entity_type or 'entity') + '-confirmation-modal') }}
+{# Confirmation modal removed - not actively used #}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Removed unused confirmation_modal call from entity_index.html
- Prevents potential Jinja2 caller() errors
- Simplifies template by removing non-functional code

## Changes
- Removed the confirmation_modal macro call from the modals block
- Added comment indicating the modal was removed as unused

## Testing
- Verified app loads without errors
- No functionality lost as modal was not actively used