### PR TITLE
Fix: DRY solution for template bugs and blank badges

### DIFF
--- a/app/templates/components/modals/wtforms_modal.html
+++ b/app/templates/components/modals/wtforms_modal.html
@@ -33,7 +33,7 @@ Direct modal rendering without wrapper nonsense
             {% if mode == 'view' %}
                 <!-- View Mode -->
                 <div class="form-fields">
-                    {{ render_filtered_fields(form, mode='view', model_name=model_name) }}
+                    {{ render_filtered_fields(form, mode='view') }}
                 </div>
             {% else %}
                 <!-- Form Mode -->
@@ -55,7 +55,7 @@ Direct modal rendering without wrapper nonsense
                     </div>
                     {% endif %}
 
-                    {{ render_filtered_fields(form, mode='form', model_name=model_name) }}
+                    {{ render_filtered_fields(form, mode='form') }}
                 </form>
             {% endif %}
         </div>

--- a/app/templates/macros/ui.html
+++ b/app/templates/macros/ui.html
@@ -62,26 +62,19 @@
 {% endmacro %}
 
 {% macro priority_badge(priority) %}
-    {% set priority_map = {
-        'high': 'danger',
-        'medium': 'warning',
-        'low': 'success'
-    } %}
-    {% set variant = priority_map.get(priority|lower, 'default') %}
-    {% set text = priority|capitalize if priority|lower in priority_map else priority %}
-    {{ badge(text, variant=variant) }}
+    {% if priority %}
+        <span class="badge badge-priority-{{ priority|lower }}">
+            {{ priority|capitalize }}
+        </span>
+    {% endif %}
 {% endmacro %}
 
 {% macro status_badge(status) %}
-    {% set status_map = {
-        'active': 'success',
-        'inactive': 'danger',
-        'pending': 'warning',
-        'completed': 'info'
-    } %}
-    {% set variant = status_map.get(status|lower, 'default') %}
-    {% set text = status|capitalize %}
-    {{ badge(text, variant=variant) }}
+    {% if status %}
+        <span class="badge badge-status-{{ status|lower|replace(' ', '-') }}">
+            {{ status|capitalize }}
+        </span>
+    {% endif %}
 {% endmacro %}
 
 {# ============================================


### PR DESCRIPTION
## Summary
- Fixed TypeError in wtforms_modal.html by removing invalid model_name parameter
- Eliminated blank badges appearing on dashboard for Tasks and Opportunities  
- Refactored badge macros to use direct CSS class generation without maps

## Changes
1. **wtforms_modal.html**: Removed `model_name` parameter from `render_filtered_fields` macro calls (lines 36, 58)
2. **ui.html**: Updated `priority_badge` and `status_badge` macros to:
   - Generate CSS classes directly (e.g., `badge-status-active`, `badge-priority-high`)
   - Only render when values exist (preventing empty badges)
   - Follow existing CSS naming conventions without mapping dictionaries

## Test Plan
- [ ] Modal forms display correctly without TypeError
- [ ] Dashboard shows no blank badges for Tasks/Opportunities without status
- [ ] Existing badges with status/priority display correctly with proper styling