### PR TITLE
fix: restore global search with DRY implementation

### DIFF
--- a/app/templates/base/includes/navbar.html
+++ b/app/templates/base/includes/navbar.html
@@ -32,15 +32,7 @@
             </div>
 
             <div class="flex items-center">
-                <div class="relative">
-                    <input type="text"
-                           id="global-search"
-                           class="w-64 pl-10 pr-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                           placeholder="Search...">
-                    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        {{ icon('magnifying-glass', size='4', class='text-gray-400') }}
-                    </div>
-                </div>
+                {{ search_widget(placeholder='Search...', id='global-search', mode='modal') }}
             </div>
         </div>
     </div>

--- a/app/templates/components/search/results.html
+++ b/app/templates/components/search/results.html
@@ -8,7 +8,7 @@
   - results: List of search result objects with id, type, title, subtitle, url
   - query: The search query string
 #}
-{% from 'macros/ui.html' import icon %}
+{% from 'macros/ui.html' import icon, entity_badge %}
 
 {% if results %}
 <div class="py-1">


### PR DESCRIPTION
## Summary
- Fixed broken global search by using the existing `search_widget` macro instead of manual HTML
- Added missing `entity_badge` import in search results template
- The search now properly displays results when typing and shows different entity types

## Root Cause
The navbar had imported but wasn't using the `search_widget` macro, instead having a manual input without HTMX attributes. Additionally, the search results template was missing the `entity_badge` import.

## Solution
- Replaced 9 lines of manual HTML with 1 line using the existing macro
- Added the missing import to fix the template error
- This is a truly DRY fix - reusing existing, working components

## Test Results
✅ Search functionality restored
✅ Results appear when typing
✅ All entity types display correctly
✅ Clicking results opens modals as expected