### PR TITLE
Unify card macros for DRY implementation

### DIFF
--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -1,5 +1,5 @@
 {% extends "base/layout.html" %}
-{% from 'macros/components.html' import section_card %}
+{% from 'macros/components.html' import card %}
 {% from 'macros/entities.html' import entity_card %}
 
 
@@ -14,7 +14,7 @@
 
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {# Overdue Tasks Section #}
-        {% call section_card(title='Overdue Tasks') %}
+        {% call card(title='Overdue Tasks') %}
             {% for task in overdue_tasks %}
                 {{ entity_card(task, 'task') }}
             {% else %}
@@ -23,7 +23,7 @@
         {% endcall %}
 
         {# Recent Notes Section #}
-        {% call section_card(title='Recent Notes') %}
+        {% call card(title='Recent Notes') %}
             {% for note in recent_notes %}
                 {{ entity_card(note, 'note') }}
             {% else %}
@@ -32,7 +32,7 @@
         {% endcall %}
 
         {# Recent Tasks Section #}
-        {% call section_card(title='Recent Tasks') %}
+        {% call card(title='Recent Tasks') %}
             {% for task in recent_tasks %}
                 {{ entity_card(task, 'task') }}
             {% else %}
@@ -41,7 +41,7 @@
         {% endcall %}
 
         {# Recent Opportunities Section #}
-        {% call section_card(title='Recent Opportunities') %}
+        {% call card(title='Recent Opportunities') %}
             {% for opportunity in recent_opportunities %}
                 {{ entity_card(opportunity, 'opportunity') }}
             {% else %}

--- a/app/templates/macros/components.html
+++ b/app/templates/macros/components.html
@@ -5,20 +5,6 @@
 {% from 'macros/ui.html' import icon %}
 
 {# ============================================
-   SECTION CARD - DRY dashboard sections
-   ============================================ #}
-{% macro section_card(title='', class='') %}
-    <div class="bg-white rounded-lg border border-gray-200 shadow-sm {{ class }}">
-        <div class="px-6 py-4 border-b border-gray-200 bg-gray-50">
-            <h2 class="text-xl font-semibold text-gray-900">{{ title }}</h2>
-        </div>
-        <div class="p-6 space-y-3">
-            {{ caller() }}
-        </div>
-    </div>
-{% endmacro %}
-
-{# ============================================
    CARD
    ============================================ #}
 {% macro card(title='', entity_type=None, compact=false, class='') %}


### PR DESCRIPTION
## Summary
- Replaced `section_card` macro with existing `card` macro in dashboard
- Removed duplicate `section_card` macro from components.html
- Achieves true DRY by using single card implementation

## Details
The `section_card` macro used inline Tailwind classes (`px-6 py-4 border-b border-gray-200 bg-gray-50`) that are functionally identical to the existing `.card-header` CSS class. By unifying to use just the `card` macro, we:
- Eliminate code duplication
- Improve maintainability
- Keep identical visual appearance

## Test plan
- [x] Dashboard renders correctly with all 4 sections
- [x] Visual appearance unchanged
- [x] No console errors