### PR TITLE
Fix: Remove invalid meta_data parameter from entity_card macro

### DIFF
--- a/app/templates/shared/entity_content.html
+++ b/app/templates/shared/entity_content.html
@@ -35,7 +35,7 @@
                 {% for entity in group.entities %}
                     {# Render all entities with the simple entity card #}
                     {% if entity.task_type is not defined or entity.task_type != 'child' %}
-                        {{ entity_card(entity, entity_type, meta_data=entity.get_meta_data()) }}
+                        {{ entity_card(entity, entity_type) }}
                     {% endif %}
                 {% endfor %}
                 


### PR DESCRIPTION
## Summary
- Fixed 500 error on /companies/content and other entity pages
- Removed invalid meta_data keyword argument from entity_card macro call

## Problem
The entity_card macro was being called with a meta_data parameter that it doesn't accept, causing a TypeError.

## Solution
Removed the unnecessary parameter - the macro already fetches meta data internally using entity.get_meta_data().

## Test Plan
- [x] Navigate to /companies page
- [x] Verify no 500 errors occur
- [x] Confirm entity cards display correctly with meta data