### PR TITLE
Refactor: Implement DRY serialization system

### DIFF
--- a/app/models/note.py
+++ b/app/models/note.py
@@ -120,16 +120,6 @@ class Note(BaseModel):
         else:
             return formatted_date  # Just show date/time for older notes
 
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert note to dictionary."""
-        return {
-            'id': self.id,
-            'content': self.content,
-            'is_internal': self.is_internal,
-            'created_at': self.created_at,
-            'entity_type': self.entity_type,
-            'entity_id': self.entity_id
-        }
 
     def to_display_dict(self) -> Dict[str, Any]:
         """
@@ -146,7 +136,7 @@ class Note(BaseModel):
             'Long content here...'
         """
         # Get base dictionary
-        result = self.to_dict()
+        result = super().to_dict()
 
         # Add note-specific computed fields
         result['entity_name'] = self.entity_name

--- a/app/models/opportunity.py
+++ b/app/models/opportunity.py
@@ -31,6 +31,21 @@ class Opportunity(BaseModel):
         'subtitle_fields': ['value', 'stage'],
         'relationships': [('company', 'name')]
     }
+
+    # Serialization configuration
+    __include_properties__ = ["calculated_priority", "deal_age"]
+    __relationship_transforms__ = {
+        "stakeholders": lambda self: [
+            {
+                "id": stakeholder["id"],
+                "name": stakeholder["name"],
+                "job_title": stakeholder["job_title"],
+                "email": stakeholder["email"],
+                "meddpicc_roles": stakeholder["meddpicc_roles"],
+            }
+            for stakeholder in self.get_stakeholders()
+        ]
+    }
     
 
     id = db.Column(db.Integer, primary_key=True)
@@ -425,67 +440,22 @@ class Opportunity(BaseModel):
     def to_dict(self) -> Dict[str, Any]:
         """
         Convert opportunity to dictionary for JSON serialization.
-        
-        Creates a comprehensive dictionary representation including
-        all database fields, computed properties, related entities,
-        and UI helper fields like CSS classes.
-        
+
+        Extends base implementation with opportunity-specific fields.
+
         Returns:
-            Dictionary containing:
-            - All database column values
-            - Computed properties (calculated_priority, deal_age)
-            - Related entity summaries (stakeholders with MEDDPICC roles)
-            - UI helper fields (company_name)
-            
-        Example:
-            >>> opp = Opportunity(name="Big Deal", stage="qualified")
-            >>> data = opp.to_dict()
-            >>> print(data['name'])
-            'Big Deal'
+            Dictionary containing all fields plus company_name and
+            value conversion to float.
         """
-        # Define properties to include beyond database columns
-        include_properties = ["calculated_priority", "deal_age"]
-        
-        # Define custom transforms for specific fields and relationships
-        field_transforms = {
-            "value": lambda val: float(val) if val else None,
-            "stakeholders": lambda _: [
-                {
-                    "id": stakeholder["id"],
-                    "name": stakeholder["name"],
-                    "job_title": stakeholder["job_title"],
-                    "email": stakeholder["email"],
-                    "meddpicc_roles": stakeholder["meddpicc_roles"],
-                }
-                for stakeholder in self.get_stakeholders()
-            ]
-        }
-        
-        # Start with base serialization - convert model to dict
-        result = {}
-        # Serialize all columns
-        for column in self.__table__.columns:
-            column_name = column.name
-            value = getattr(self, column_name, None)
-            # Handle datetime/date serialization
-            if isinstance(value, (datetime, date)):
-                result[column_name] = value.isoformat() if value else None
-            else:
-                result[column_name] = value
+        result = super().to_dict()
 
-        # Add custom properties and transforms
-        for prop in include_properties:
-            if hasattr(self, prop):
-                result[prop] = getattr(self, prop)
-
-        # Apply field transforms
-        for field, transform in field_transforms.items():
-            if field in result:
-                result[field] = transform(result[field])
-        
         # Add computed company name
         result["company_name"] = self.company.name if self.company else None
-        
+
+        # Ensure value is float
+        if "value" in result and result["value"] is not None:
+            result["value"] = float(result["value"])
+
         return result
 
     def to_display_dict(self) -> Dict[str, Any]:

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -47,6 +47,20 @@ class Task(BaseModel):
         'subtitle_fields': ['due_date', 'priority', 'status']
     }
 
+    # Serialization configuration
+    __include_properties__ = [
+        "is_overdue", "opportunity_value", "company_name",
+        "opportunity_name", "opportunity_stage", "stakeholder_opportunity_name",
+        "stakeholder_opportunity_value", "task_type_badge", "can_start",
+        "completion_percentage"
+    ]
+    __relationship_transforms__ = {
+        "linked_entities": lambda self: [
+            {"type": entity["type"], "id": entity["id"], "name": entity["name"]}
+            for entity in self.linked_entities
+        ]
+    }
+
     id = db.Column(db.Integer, primary_key=True)
     description = db.Column(
         db.Text,
@@ -477,67 +491,8 @@ class Task(BaseModel):
 
 
     def to_dict(self) -> Dict[str, Any]:
-        """
-        Convert task to dictionary for JSON serialization.
-        
-        Creates a comprehensive dictionary representation including
-        all database fields, computed properties, linked entities,
-        and UI helper fields like CSS classes.
-        
-        Returns:
-            Dictionary containing:
-            - All database column values
-            - Computed properties (is_overdue, completion_percentage, etc.)
-            - Linked entity information
-            - UI helper fields
-            
-        Example:
-            >>> task = Task(description="Follow up", priority="high")
-            >>> data = task.to_dict()
-            >>> print(data['description'])
-            'Follow up'
-        """
-        # Define properties to include beyond database columns
-        include_properties = [
-            "is_overdue", "opportunity_value", "company_name",
-            "opportunity_name", "opportunity_stage", "stakeholder_opportunity_name",
-            "stakeholder_opportunity_value", "task_type_badge", "can_start",
-            "completion_percentage"
-        ]
-        
-        # Define custom transforms for specific fields
-        field_transforms = {
-            "priority": lambda val: val,  # Keep as-is but add CSS class separately
-            "status": lambda val: val,    # Keep as-is but add CSS class separately
-            "linked_entities": lambda _: [
-                {"type": entity["type"], "id": entity["id"], "name": entity["name"]}
-                for entity in self.linked_entities
-            ]
-        }
-        
-        # Start with base serialization - convert model to dict
-        result = {}
-        # Serialize all columns
-        for column in self.__table__.columns:
-            column_name = column.name
-            value = getattr(self, column_name, None)
-            # Handle datetime/date serialization
-            if isinstance(value, (datetime, date)):
-                result[column_name] = value.isoformat() if value else None
-            else:
-                result[column_name] = value
-
-        # Add custom properties and transforms
-        for prop in include_properties:
-            if hasattr(self, prop):
-                result[prop] = getattr(self, prop)
-
-        # Apply field transforms
-        for field, transform in field_transforms.items():
-            if field in result:
-                result[field] = transform(result[field])
-
-        return result
+        """Convert task to dictionary for JSON serialization."""
+        return super().to_dict()
 
     def to_display_dict(self) -> Dict[str, Any]:
         """

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -75,19 +75,6 @@ class User(BaseModel):
     })
     created_at = db.Column(db.DateTime, default=datetime.utcnow, info={'display_label': 'Created At'})
 
-    def to_dict(self):
-        """Convert user to dictionary for JSON serialization"""
-        result = {}
-        # Serialize all columns
-        for column in self.__table__.columns:
-            column_name = column.name
-            value = getattr(self, column_name, None)
-            # Handle datetime/date serialization
-            if isinstance(value, (datetime, date)):
-                result[column_name] = value.isoformat() if value else None
-            else:
-                result[column_name] = value
-        return result
 
     def get_company_assignments(self):
         """Get all companies this user is assigned to"""

--- a/chatbot/models/chat_history.py
+++ b/chatbot/models/chat_history.py
@@ -49,14 +49,6 @@ class ChatHistory(BaseModel):
     # Timestamps
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Convert chat history to dictionary for JSON serialization.
-        
-        Returns:
-            Dictionary representation of the chat history record.
-        """
-        return super().to_dict()
 
     def __repr__(self) -> str:
         """Return string representation of the chat history."""

--- a/chatbot/models/embedding.py
+++ b/chatbot/models/embedding.py
@@ -52,14 +52,6 @@ class Embedding(BaseModel):
     # Index for faster lookups
     __table_args__ = (db.Index("idx_content_type_id", "content_type", "content_id"),)
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Convert embedding to dictionary for JSON serialization.
-        
-        Returns:
-            Dictionary representation of the embedding model.
-        """
-        return super().to_dict()
 
     def __repr__(self) -> str:
         """Return string representation of the embedding."""


### PR DESCRIPTION
## Summary
- Implemented a DRY (Don't Repeat Yourself) serialization system by adding a base `to_dict()` method in BaseModel
- Removed ~200 lines of duplicated serialization code across all models
- Maintained full backward compatibility with existing API endpoints

## Changes
### Base Implementation
- Added `to_dict()` method to BaseModel that handles:
  - Automatic column serialization
  - DateTime/date to ISO format conversion  
  - Configurable property inclusion via `__include_properties__`
  - Relationship transforms via `__relationship_transforms__`

### Model Updates
- **Company**: Configured with properties and relationship transforms
- **Opportunity**: Simplified to use base method with minimal override
- **Stakeholder**: Configured serialization via class attributes
- **Task**: Configured with extensive properties list
- **User**: Removed redundant implementation (uses base directly)
- **Note**: Removed redundant implementation
- **ChatHistory/Embedding**: Removed unnecessary overrides

## Benefits
- ✅ Single source of truth for serialization logic
- ✅ Consistent datetime handling across all models
- ✅ Easy to extend - models just define configuration
- ✅ Cleaner, more maintainable code
- ✅ Full backward compatibility maintained

## Testing
- Tested all API endpoints - all working correctly
- Companies, opportunities, stakeholders return proper JSON with relationships
- Create/update operations work as expected
- Task-specific endpoints maintain functionality

## Note on field_transforms
The `field_transforms` (now `__relationship_transforms__`) were kept as they're necessary to:
- Control what data from relationships gets serialized
- Prevent infinite recursion (Company → Stakeholder → Company)
- Optimize API response size