### PR TITLE
Fix: Restore badge colors with DRY CSS implementation

### DIFF
--- a/app/static/css/components/badges.css
+++ b/app/static/css/components/badges.css
@@ -1,6 +1,6 @@
 /**
- * Badge Component Styles
- * Following ADR pattern - CSS classes for dynamic Jinja generation
+ * Badge Component - Ultra DRY Implementation
+ * Single source of truth for all badge styles
  */
 
 /* Base badge styles */
@@ -12,9 +12,12 @@
     font-size: 0.75rem;
     font-weight: 500;
     line-height: 1;
+    /* Default colors as fallback */
+    background-color: #f3f4f6;
+    color: #374151;
 }
 
-/* Badge variants - dynamically generated as badge-{variant} */
+/* Badge variants - Direct class mapping */
 .badge-default {
     background-color: #f3f4f6;
     color: #374151;
@@ -45,7 +48,7 @@
     color: #3730a3;
 }
 
-/* Priority badges - dynamically generated as badge-{priority} */
+/* Priority badges */
 .badge-high {
     background-color: #fee2e2;
     color: #991b1b;
@@ -61,7 +64,7 @@
     color: #1e40af;
 }
 
-/* Status badges - dynamically generated as badge-{status} */
+/* Status badges */
 .badge-complete,
 .badge-completed,
 .badge-done {
@@ -75,7 +78,8 @@
     color: #1e40af;
 }
 
-.badge-pending {
+.badge-pending,
+.badge-todo {
     background-color: #fed7aa;
     color: #92400e;
 }
@@ -85,39 +89,70 @@
     color: #374151;
 }
 
-/* Entity badges - dynamically generated as badge-entity-{type} */
-.badge-entity-company {
-    background-color: #dbeafe; /* blue-100 */
-    color: #1e40af; /* blue-800 */
+/* Entity type badges */
+.badge-company {
+    background-color: #dbeafe;
+    color: #1e40af;
 }
 
-.badge-entity-contact,
-.badge-entity-stakeholder {
-    background-color: #d1fae5; /* green-100 */
-    color: #065f46; /* green-800 */
+.badge-contact,
+.badge-stakeholder {
+    background-color: #d1fae5;
+    color: #065f46;
 }
 
-.badge-entity-opportunity {
-    background-color: #ede9fe; /* purple-100 */
-    color: #5b21b6; /* purple-800 */
+.badge-opportunity {
+    background-color: #ede9fe;
+    color: #5b21b6;
 }
 
-.badge-entity-task {
-    background-color: #fed7aa; /* orange-100 */
-    color: #9a3412; /* orange-800 */
+.badge-task {
+    background-color: #fed7aa;
+    color: #9a3412;
 }
 
-.badge-entity-user {
-    background-color: #e0e7ff; /* indigo-100 */
-    color: #3730a3; /* indigo-800 */
+.badge-user {
+    background-color: #e0e7ff;
+    color: #3730a3;
 }
 
-.badge-entity-note {
-    background-color: #fef3c7; /* yellow-100 */
-    color: #92400e; /* yellow-800 */
+.badge-note {
+    background-color: #fef3c7;
+    color: #92400e;
 }
 
-/* Badge sizes - dynamically generated as badge-{size} */
+/* Opportunity stage badges */
+.badge-lead {
+    background-color: #e0e7ff;
+    color: #3730a3;
+}
+
+.badge-qualified {
+    background-color: #dbeafe;
+    color: #1e40af;
+}
+
+.badge-proposal {
+    background-color: #fed7aa;
+    color: #92400e;
+}
+
+.badge-negotiation {
+    background-color: #fed7aa;
+    color: #9a3412;
+}
+
+.badge-closed-won {
+    background-color: #d1fae5;
+    color: #065f46;
+}
+
+.badge-closed-lost {
+    background-color: #fee2e2;
+    color: #991b1b;
+}
+
+/* Badge sizes */
 .badge-sm {
     padding: 0.125rem 0.5rem;
     font-size: 0.625rem;

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -12,6 +12,9 @@
 /* Card component styles */
 @import url('components/cards.css');
 
+/* Badge component styles */
+@import url('components/badges.css');
+
 /* Modal overlay utilities (minimal custom) */
 @import url('components/modal.css');
 

--- a/app/templates/macros/ui.html
+++ b/app/templates/macros/ui.html
@@ -84,7 +84,7 @@
 
 {% macro typed_badge(value, type) %}
     {% if value %}
-        <span class="badge badge-{{ type }}-{{ value|lower|replace(' ', '-') }}">
+        <span class="badge badge-{{ value|lower|replace(' ', '-') }}">
             {{ value|capitalize }}
         </span>
     {% endif %}


### PR DESCRIPTION
## Summary
- Fixed missing badge background colors by importing badges.css
- Simplified badge class generation for cleaner, DRY implementation
- All badges now display with proper color coding

## Changes
1. Added badges.css import to main.css 
2. Simplified typed_badge macro to generate clean class names (badge-low instead of badge-priority-low)
3. Implemented comprehensive badge color system for priorities, statuses, and entity types

## Test Plan
- [x] Verified badges display with correct background colors
- [x] Tested priority badges (Low=blue, Medium=orange, High=red)
- [x] Tested status badges (Todo=orange, In-progress=blue, Complete=green)
- [x] Confirmed DRY solution works for all badge types