### PR TITLE
feat: add New entity buttons to dashboard and entity cards

### DIFF
--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -10,6 +10,21 @@
     <div class="section-spacing">
         <h1 class="page-title">Dashboard</h1>
         <p class="page-subtitle">Overview of your CRM performance and activity</p>
+
+        {# DRY: Use existing entity_types from backend #}
+        {% if entity_types %}
+        <div class="page-actions">
+            {% for entity_type in entity_types %}
+                <a href="/modals/{{ entity_type }}/create"
+                   hx-get="/modals/{{ entity_type }}/create"
+                   hx-target="#modal-container"
+                   hx-swap="innerHTML"
+                   class="btn btn-primary">
+                    New {{ entity_type.title() }}
+                </a>
+            {% endfor %}
+        </div>
+        {% endif %}
     </div>
 
     <div class="grid-responsive-2">

--- a/app/templates/macros/entities.html
+++ b/app/templates/macros/entities.html
@@ -26,6 +26,13 @@
             </h3>
             {% if show_actions %}
                 <div class="entity-card-actions">
+                    <a href="/modals/{{ entity_type }}/create"
+                       hx-get="/modals/{{ entity_type }}/create"
+                       hx-target="#modal-container"
+                       hx-swap="innerHTML"
+                       class="entity-card-action">
+                        {{ icon('plus', size='4') }}
+                    </a>
                     <a href="{{ entity.get_view_url() }}"
                        hx-get="{{ entity.get_view_url() }}"
                        hx-target="#modal-container"


### PR DESCRIPTION
## Summary
- Add "New <entity>" buttons to dashboard using existing entity_types from DashboardService  
- Add plus icon "New" action to entity cards alongside view/edit/delete
- Maintains DRY patterns - zero hardcoding, all entity types discovered dynamically

## Test plan
- [ ] Verify dashboard shows New buttons for all entity types
- [ ] Test HTMX modal integration works for creation forms  
- [ ] Confirm entity cards show new plus icon action
- [ ] Validate all buttons use correct `/modals/{entity_type}/create` URLs