### PR TITLE
feat: implement dynamic search for Pipeline Stage with custom ordering

### DIFF
--- a/app/forms/__init__.py
+++ b/app/forms/__init__.py
@@ -22,6 +22,7 @@ def get_field_choices(field_name):
         "industry": "Company",
         "size": "Company",
         "status": "Opportunity",
+        "stage": "Opportunity",
         "priority": "Task",
         "type": "Stakeholder"
     }

--- a/app/routes/web/search.py
+++ b/app/routes/web/search.py
@@ -189,8 +189,14 @@ def _handle_choice_search(query, choice_field, mode, field_name):
                 "url": "#"  # Not used for choices
             })
 
-    # Sort by label
-    results.sort(key=lambda x: x["title"])
+    # Sort by label, with custom ordering for stage field
+    if choice_field == "stage":
+        # Define custom order for pipeline stages
+        stage_order = ["prospect", "qualified", "proposal", "negotiation", "closed-won", "closed-lost"]
+        stage_order_map = {stage: i for i, stage in enumerate(stage_order)}
+        results.sort(key=lambda x: stage_order_map.get(x["id"].lower(), 999))
+    else:
+        results.sort(key=lambda x: x["title"])
 
     return render_template(
         "components/search/results.html",

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -46,6 +46,27 @@
                 <p class="form-error">{{ error }}</p>
             {% endfor %}
         {% endif %}
+    {# Special handling for stage fields with choice search #}
+    {% elif field.name == 'stage' and field.type == 'SelectField' %}
+        {% set stage_choices = {} %}
+        {% for value, label in field.choices %}
+            {% if value %}
+                {% set _ = stage_choices.update({value: {'label': label, 'description': ''}}) %}
+            {% endif %}
+        {% endfor %}
+        {{ choice_search_dropdown(
+            name=field.name,
+            choices=stage_choices,
+            value=field.data or '',
+            label=field.label.text if show_label else '',
+            required=field.flags.required,
+            placeholder='Search pipeline stages...'
+        ) }}
+        {% if show_errors and field.errors %}
+            {% for error in field.errors %}
+                <p class="form-error">{{ error }}</p>
+            {% endfor %}
+        {% endif %}
     {% else %}
         <div class="form-field-group">
             {% if show_label and field.label.text %}


### PR DESCRIPTION
## Summary
- Replace static dropdown with dynamic search for Pipeline Stage field in Create Opportunity modal
- Implement custom ordering for pipeline stages as requested: Prospect, Qualified, Proposal, Negotiation, Closed Won, Closed Lost
- Maintain consistency with existing Company and Industry dynamic search patterns

## Changes Made
- **app/forms/__init__.py**: Added "stage" to field_model_map for choice search support
- **app/templates/macros/forms.html**: Added special handling for stage fields with choice_search_dropdown  
- **app/routes/web/search.py**: Implemented custom ordering logic for pipeline stages

## Test Plan
- ✅ Create Opportunity modal opens correctly
- ✅ Pipeline Stage field displays as dynamic search input  
- ✅ Search functionality works (typing filters results)
- ✅ Results display in correct order: Prospect → Qualified → Proposal → Negotiation → Closed Won → Closed Lost
- ✅ Interface matches existing Company search field pattern