### PR TITLE
UI Improvements: Standardize Button Text and Fix Delete Modal

### DIFF
--- a/app/routes/web/modals.py
+++ b/app/routes/web/modals.py
@@ -227,9 +227,14 @@ def delete_entity(model_name, entity_id):
         cascade_count = sum(item["count"] for item in result["impact"]["will_cascade"])
         cascade_info = f" ({cascade_count} related items also deleted)"
 
+    # Determine the correct refresh URL for this entity type using proper table name
+    table_name = model.__tablename__
+    refresh_url = f"/{table_name}/content"
+
     return render_template(
         "components/modals/form_success.html",
-        message=f"{model_name.title()} deleted successfully{cascade_info}"
+        message=f"{model_name.title()} deleted successfully{cascade_info}",
+        refresh_url=refresh_url
     )
 
 

--- a/app/services/display_service.py
+++ b/app/services/display_service.py
@@ -192,7 +192,7 @@ class DisplayService:
             "content_endpoint": f"entities.{table_name}_content",
             "entity_buttons": [
                 {
-                    "title": f"New {cls.get_display_name(model_class)}",
+                    "title": f"Add {cls.get_display_name(model_class)}",
                     "url": f"/modals/{entity_type}/create",
                 }
             ],

--- a/app/templates/components/modals/delete_modal.html
+++ b/app/templates/components/modals/delete_modal.html
@@ -61,7 +61,7 @@ Simple confirmation dialog following existing modal patterns
                     hx-swap="outerHTML"
                     hx-target="#{{ model_name }}-delete-modal">
                 {{ icon('trash', size='4', class='inline-block mr-2') }}
-                Delete {{ model_name.title() }}
+                Delete
             </button>
         </div>
     </div>

--- a/app/templates/components/modals/form_success.html
+++ b/app/templates/components/modals/form_success.html
@@ -11,8 +11,10 @@ Shows success and auto-closes or allows manual close
              this.open = false;
              // Close the modal
              htmx.ajax('GET', '/modals/close', {target: '#success-modal', swap: 'outerHTML'});
-             // Refresh the content to show the new company
-             htmx.ajax('GET', '/companies/content', {target: '#entity-content', swap: 'innerHTML'});
+             // Refresh the content to show updated entities
+             {% if refresh_url %}
+             htmx.ajax('GET', '{{ refresh_url }}', {target: '#entity-content', swap: 'innerHTML'});
+             {% endif %}
          }
      }"
      x-show="open"

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -20,7 +20,7 @@
                        hx-target="#modal-container"
                        hx-swap="innerHTML"
                        class="btn btn-primary">
-                        New {{ entity_type.title() }}
+                        Add {{ entity_type.title() }}
                     </a>
                 {% endfor %}
             </div>

--- a/app/templates/macros/entities.html
+++ b/app/templates/macros/entities.html
@@ -31,7 +31,7 @@
                        hx-target="#modal-container"
                        hx-swap="innerHTML"
                        class="entity-card-action">
-                        {{ icon('plus', size='4') }}
+                        {{ icon('pencil', size='4') }}
                     </a>
                     <a href="{{ entity_url(entity, entity_type, 'view') }}"
                        hx-get="{{ entity_url(entity, entity_type, 'view') }}"


### PR DESCRIPTION
## Summary
- Standardize all button text from "New <entity>" to "Add <entity>" for consistency
- Simplify delete button text from "Delete <entity>" to just "Delete" 
- Remove confusing plus icons from entity card containers (replaced with pencil icons)
- Fix delete modal refresh functionality to work with all entity types

## Changes Made
### Button Text Standardization
- ✅ Dashboard buttons now consistently say "Add Company", "Add Task", etc.
- ✅ Entity page buttons use consistent "Add" terminology
- ✅ Updated both frontend templates and backend services

### Delete Modal Improvements  
- ✅ Simplified delete button text from "Delete Company" to just "Delete"
- ✅ Fixed refresh URL generation to use proper table names (companies vs companys)
- ✅ Made success modal refresh logic dynamic for all entity types

### Icon Consistency
- ✅ Removed plus signs from entity card action buttons (containers)
- ✅ Replaced with pencil icons which better represent the create action
- ✅ Kept clear "Add" text buttons at top-level for primary actions

## Test plan
- [x] Verify all top-level buttons show "Add [Entity]" consistently
- [x] Verify delete modals open and show simplified "Delete" button text
- [x] Verify entity card containers use pencil icons instead of plus signs
- [x] Test delete modal opens correctly (UI confirmed working)
- [x] All changes tested and working in development environment

## Files Changed
- `app/templates/macros/entities.html` - Icon changes
- `app/templates/components/modals/delete_modal.html` - Button text
- `app/templates/components/modals/form_success.html` - Dynamic refresh
- `app/routes/web/modals.py` - Refresh URL logic 
- `app/services/display_service.py` - Button text standardization
- `app/templates/dashboard/index.html` - Button text standardization