### PR TITLE
fix: enhance delete functionality with immediate DOM removal

### DIFF
--- a/app/routes/web/modals.py
+++ b/app/routes/web/modals.py
@@ -234,7 +234,8 @@ def delete_entity(model_name, entity_id):
     return render_template(
         "components/modals/form_success.html",
         message=f"{model_name.title()} deleted successfully{cascade_info}",
-        refresh_url=refresh_url
+        refresh_url=refresh_url,
+        deleted_entity_id=f"entity-{model_name}-{entity_id}"
     )
 
 

--- a/app/templates/components/modals/form_success.html
+++ b/app/templates/components/modals/form_success.html
@@ -11,6 +11,19 @@ Shows success and auto-closes or allows manual close
              this.open = false;
              // Close the modal
              htmx.ajax('GET', '/modals/close', {target: '#success-modal', swap: 'outerHTML'});
+
+             {% if deleted_entity_id %}
+             // Immediately remove the deleted entity from the DOM
+             const deletedElement = document.getElementById('{{ deleted_entity_id }}');
+             if (deletedElement) {
+                 deletedElement.style.transition = 'opacity 0.3s ease-out';
+                 deletedElement.style.opacity = '0';
+                 setTimeout(() => {
+                     deletedElement.remove();
+                 }, 300);
+             }
+             {% endif %}
+
              // Refresh the content to show updated entities
              {% if refresh_url %}
              htmx.ajax('GET', '{{ refresh_url }}', {target: '#entity-content', swap: 'innerHTML'});

--- a/app/templates/macros/entities.html
+++ b/app/templates/macros/entities.html
@@ -12,6 +12,7 @@
     {# DRY: Use display config from backend, no hardcoded entity types #}
 
     <div class="entity-card-container"
+         id="entity-{{ entity_type }}-{{ entity.id }}"
          data-entity="{{ entity_type }}"
          data-entity-id="{{ entity.id }}">
         <div class="entity-card-header">


### PR DESCRIPTION
## Summary
- Fixes delete functionality to ensure deleted entities disappear immediately without requiring page refresh
- Adds proper DOM targeting and removal with smooth animations
- Ensures consistent behavior across all entity types (companies, stakeholders, opportunities, tasks, users, notes)

## Changes Made
- **Entity Card Containers**: Added unique IDs (`entity-{type}-{id}`) for proper HTMX targeting
- **Delete Route**: Enhanced to pass `deleted_entity_id` parameter to success template  
- **Success Template**: Implemented immediate DOM removal with 300ms fade-out animation
- **Cross-Entity Support**: Works uniformly across all entity types in MODEL_REGISTRY

## Test Plan
- [x] Tested task deletion - entity disappears immediately with smooth animation
- [x] Verified delete modal functionality across multiple entity types
- [x] Confirmed no page refresh required for UI updates
- [x] Validated proper error handling for entities with dependencies

## Technical Details
The fix addresses the root cause where deleted entities remained visible until manual page refresh by:
1. Adding targetable container IDs to entity cards
2. Passing the specific entity ID to the success modal
3. Using JavaScript to immediately remove the deleted element from DOM
4. Providing visual feedback with smooth fade-out transition

Resolves issue where users had to manually refresh to see deleted items disappear.