### PR TITLE
Fix entity editing validation issue

### DIFF
--- a/app/routes/web/modals.py
+++ b/app/routes/web/modals.py
@@ -280,7 +280,9 @@ def update_entity(model_name, entity_id):
     """Update existing entity - POST handler."""
     model, form_class = get_model_and_form(model_name)
     entity = model.query.get_or_404(entity_id)
-    return process_form_submission(model_name, model, form_class(obj=entity), entity)
+    form = form_class(obj=entity)
+    form._obj = entity  # Set _obj for validation to recognize we're editing this entity
+    return process_form_submission(model_name, model, form, entity)
 
 
 @modals_bp.route("/<model_name>/<int:entity_id>/delete", methods=["POST"])


### PR DESCRIPTION
## Summary
- Fixed validation error when editing entities that incorrectly flagged the entity's own name as duplicate
- Set the `_obj` attribute on forms during updates to allow validation to recognize we're editing the same entity

## Problem
When editing an entity (e.g., a company), users would get the error "A company with this name already exists" even when not changing the name. This occurred because:
1. The form validation checks for `self._obj` to allow editing the same record
2. The `_obj` attribute was never set when instantiating forms with `obj=entity`
3. Therefore validation always failed when encountering the entity's existing name

## Solution
Modified the `update_entity` function in `/app/routes/web/modals.py` to properly set `form._obj = entity` after form instantiation. This minimal change ensures the validation logic works correctly without modifying form classes.

## Test Plan
- [x] Edit a company without changing its name - should save successfully
- [x] Edit a company and change to an existing company's name - should show validation error
- [x] Create a new company with a duplicate name - should show validation error