### PR TITLE
Fix dropdown widths for better content display

### DIFF
--- a/app/templates/macros/components.html
+++ b/app/templates/macros/components.html
@@ -128,7 +128,7 @@
         <button class="absolute right-2 top-2 text-gray-400 hover:text-gray-600">
             {{ icon('magnifying-glass') }}
         </button>
-        <div id="{{ id }}-results" class="absolute top-full mt-1 w-[32rem] max-w-2xl bg-white border border-gray-200 rounded-md shadow-lg hidden z-50"></div>
+        <div id="{{ id }}-results" class="absolute top-full mt-1 w-96 bg-white border border-gray-200 rounded-md shadow-lg hidden z-50"></div>
     </div>
 {% endmacro %}
 
@@ -243,7 +243,7 @@
     <div class="flex flex-wrap gap-3 items-center">
         {% for dropdown_key, config in dropdowns.items() %}
             {% if config.options %}
-                <div class="min-w-48">
+                <div class="w-64">
                     {% if config.label %}
                         <label class="block text-sm font-medium text-gray-700 mb-1">
                             {{ config.label }}


### PR DESCRIPTION
## Summary
- Adjusted dropdown widths to properly accommodate icon + name + badge layout
- Global search dropdown: reduced from 32rem (512px) to 24rem (384px) 
- Entity dropdowns (Group By, Sort By, etc): increased from min-w-48 (192px) to w-64 (256px)

## Changes
- Modified `app/templates/macros/components.html`:
  - Global search results: `w-[32rem] max-w-2xl` → `w-96`
  - Entity dropdown containers: `min-w-48` → `w-64`

## Test plan
- [x] Test global search dropdown displays correctly with reduced width
- [x] Test entity dropdowns (Group By, Sort By) have enough space for content
- [x] Verify dropdowns accommodate icon + name + badge without overflow