### PR TITLE
Fix user stats to show more relevant metrics

### DIFF
--- a/app/core/stats.py
+++ b/app/core/stats.py
@@ -253,23 +253,20 @@ class StatsGenerator:
         Returns:
             List of user statistics.
         """
-        from app.models import Task, Opportunity
+        from app.models import Task, Opportunity, User
 
         stats = []
 
-        # Active users
-        active = (
-            db.session.query(func.count(func.distinct(Task.assigned_to_id))).scalar()
-            or 0
-        )
-        stats.append(Stat(label="Active Members", value=active))
+        # Total team members
+        team_members = User.query.count()
+        stats.append(Stat(label="Team Members", value=team_members))
 
-        # Opportunities owned
-        opps_owned = Opportunity.query.filter(Opportunity.owner_id.isnot(None)).count()
-        stats.append(Stat(label="Opportunities Owned", value=opps_owned))
+        # Total opportunities
+        total_opps = Opportunity.query.count()
+        stats.append(Stat(label="Total Opportunities", value=total_opps))
 
         # Open tasks
-        open_tasks = Task.query.filter(Task.status != "completed").count()
+        open_tasks = Task.query.filter(Task.status != "complete").count()
         stats.append(Stat(label="Open Tasks", value=open_tasks))
 
         return stats


### PR DESCRIPTION
## Summary
- Updated user statistics to show more meaningful metrics
- Fixed task status comparison bug (was using "completed" instead of "complete")

## Changes
- Changed "Active Members" to "Team Members" showing total user count
- Changed "Opportunities Owned" to "Total Opportunities" showing all opportunities  
- Fixed task status comparison to use the correct "complete" value

## Test Plan
- [ ] Verify stats display correctly on dashboard
- [ ] Confirm Team Members count matches total users
- [ ] Confirm Total Opportunities count is accurate
- [ ] Verify Open Tasks excludes "complete" status tasks