### PR TITLE
Fix badge display issues across the application

### DIFF
--- a/app/routes/web/entities.py
+++ b/app/routes/web/entities.py
@@ -142,7 +142,7 @@ def entity_content(model: type, table_name: str) -> str:
 
         # Convert to list format expected by template
         grouped_list = [
-            {"key": key, "label": key, "entities": entities}
+            {"key": key, "label": key, "entities": entities, "count": len(entities)}
             for key, entities in grouped_entities.items()
         ]
 
@@ -166,6 +166,7 @@ def entity_content(model: type, table_name: str) -> str:
             "key": "all",
             "label": f"All {get_plural_name(model.__name__)}",
             "entities": entities,
+            "count": len(entities),
         }
     ]
 

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -3,7 +3,7 @@
     Handles WTForms rendering, field filters, validation
 #}
 
-{% from 'macros/ui.html' import icon %}
+{% from 'macros/ui.html' import icon, priority_badge, status_badge %}
 {% from 'macros/components.html' import entity_search_dropdown, choice_search_dropdown, multiple_choice_search_dropdown %}
 
 {# ============================================
@@ -374,10 +374,25 @@
         <label class="form-label">{{ field.label.text }}</label>
         <div class="form-field-view">
             {% if field.type == 'SelectField' %}
-                {% for value, label in field.choices %}
-                    {% if value == field.data %}{{ label }}{% endif %}
-                {% endfor %}
-                {% if not field.data %}
+                {# DRY badge rendering based on field name patterns #}
+                {% set field_lower = field.name.lower() %}
+                {% if field.data %}
+                    {% if 'priority' in field_lower %}
+                        {{ priority_badge(field.data) }}
+                    {% elif 'status' in field_lower %}
+                        {{ status_badge(field.data) }}
+                    {% elif 'stage' in field_lower %}
+                        {# Opportunity stages get badges too #}
+                        <span class="badge badge-{{ field.data|badge_class }}">
+                            {{ field.data }}
+                        </span>
+                    {% else %}
+                        {# Default select field display #}
+                        {% for value, label in field.choices %}
+                            {% if value == field.data %}{{ label }}{% endif %}
+                        {% endfor %}
+                    {% endif %}
+                {% else %}
                     <span class="form-field-view-empty">Not set</span>
                 {% endif %}
             {% elif field.type == 'TextAreaField' %}

--- a/app/templates/macros/ui.html
+++ b/app/templates/macros/ui.html
@@ -86,7 +86,7 @@
 {% macro typed_badge(value, type) %}
     {% if value %}
         <span class="badge badge-{{ value|badge_class|replace(' ', '-') }}">
-            {{ value|badge_class }}
+            {{ value }}
         </span>
     {% endif %}
 {% endmacro %}

--- a/app/utils/template_utils.py
+++ b/app/utils/template_utils.py
@@ -3,7 +3,7 @@
 
 def badge_class(value):
     """Convert value to badge-compatible CSS class."""
-    return str(value).lower().replace("_", " ").replace("-", " ") if value else ""
+    return str(value).lower().replace("_", "-").replace(" ", "-") if value else ""
 
 
 def get_dashboard_action_buttons():


### PR DESCRIPTION
## Summary
- Fixed multiple badge display issues including empty text and missing count badges
- Implemented DRY solution for automatic badge rendering based on field name patterns
- Corrected CSS class generation for valid badge styling

## Changes

### 1. Fixed count property for grouped entities (`ecf6caf`)
- Added `count` property to grouped_list dictionaries in entities.py
- Count badges now correctly display the number of entities in each group
- Fixes empty badges that were showing in entity group headers

### 2. Fixed badge_class filter (`fce5ac7`) 
- Updated filter to replace spaces with hyphens instead of converting to spaces
- Ensures CSS class names are valid (spaces are not allowed in CSS classes)
- Fixes badge styling issues caused by invalid class names

### 3. Fixed badge text display (`9e267e3`)
- Changed typed_badge macro to show original value as text
- Badge class still uses filtered value for styling
- Fixes issue where badges showed processed text instead of readable labels

### 4. Implemented DRY badge rendering (`ad0b32d`)
- Auto-detect badge fields based on name patterns (priority, status, stage)
- Pattern matching instead of exact field name checks
- Makes badge system extensible for future field types
- Reduces code duplication

## Test Results
- ✅ Count badges now display correctly (e.g., "3" next to "All Tasks")
- ✅ Badge CSS classes are properly formatted without spaces
- ✅ Badge text displays readable values
- ⚠️ Note: Priority/Status badges in modals may require template cache clearing to see changes

## Screenshots
Count badges now working properly in grouped entity views.