### PR TITLE
Convert dropdowns to standard UI with multi-select support

### DIFF
--- a/app/core/dropdowns.py
+++ b/app/core/dropdowns.py
@@ -115,7 +115,7 @@ class DropdownBuilder:
             options=options,
             current_value=request_args.get("group_by", ""),
             placeholder="Group by...",
-            searchable=True,
+            searchable=False,
             label="Group By",
         )
 
@@ -150,7 +150,7 @@ class DropdownBuilder:
             options=options,
             current_value=request_args.get("sort_by", default_sort),
             placeholder="Sort by...",
-            searchable=True,
+            searchable=False,
             label="Sort By",
         )
 

--- a/app/core/dropdowns.py
+++ b/app/core/dropdowns.py
@@ -79,10 +79,8 @@ class DropdownBuilder:
                 current_value=request_args.get(field_name, ""),
                 placeholder=f'All {field_info["label"]}',
                 label=field_info["label"],
-                searchable=(
-                    field_name == "industry" or len(options) > 8
-                ),  # Make Industry and large lists searchable
-                multiple=True,  # Enable multi-select for all filter dropdowns
+                searchable=False,  # Use standard dropdowns
+                multiple=True,  # Enable multi-select for filter dropdowns
             )
 
             dropdowns[f"filter_{field_name}"] = config.to_dict()

--- a/app/core/dropdowns.py
+++ b/app/core/dropdowns.py
@@ -82,6 +82,7 @@ class DropdownBuilder:
                 searchable=(
                     field_name == "industry" or len(options) > 8
                 ),  # Make Industry and large lists searchable
+                multiple=True,  # Enable multi-select for all filter dropdowns
             )
 
             dropdowns[f"filter_{field_name}"] = config.to_dict()

--- a/app/forms/entities/stakeholder.py
+++ b/app/forms/entities/stakeholder.py
@@ -4,7 +4,7 @@ Stakeholder Forms
 Simple stakeholder form using WTForms with model introspection.
 """
 
-from wtforms import StringField, TextAreaField, HiddenField
+from wtforms import StringField, TextAreaField, HiddenField, SelectMultipleField
 from wtforms.validators import DataRequired, Optional, Length
 from ..base.base_forms import BaseForm
 
@@ -14,6 +14,13 @@ class StakeholderForm(BaseForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Populate MEDDPICC role choices
+        from app.models.enums import MeddpiccRole
+
+        self.meddpicc_roles_select.choices = [
+            (role.value, role.value.replace("_", " ").title())
+            for role in MeddpiccRole
+        ]
 
     name = StringField(
         "Full Name",
@@ -29,7 +36,14 @@ class StakeholderForm(BaseForm):
 
     company = StringField("Company", validators=[DataRequired()])
 
-    meddpicc_roles = HiddenField("MEDDPICC Roles")
+    meddpicc_roles = HiddenField("MEDDPICC Roles")  # Keep for backward compatibility
+
+    meddpicc_roles_select = SelectMultipleField(
+        "MEDDPICC Roles",
+        choices=[],  # Will be populated in __init__
+        validators=[Optional()],
+        render_kw={"class": "form-select", "size": "8"}
+    )
 
     comments = TextAreaField(
         "Comments",
@@ -42,4 +56,4 @@ class StakeholderForm(BaseForm):
 
     def get_display_fields(self):
         """Return field names to display in modal, in this exact order"""
-        return ["name", "job_title", "company", "meddpicc_roles", "comments"]
+        return ["name", "job_title", "company", "meddpicc_roles_select", "comments"]

--- a/app/forms/tasks/task_forms.py
+++ b/app/forms/tasks/task_forms.py
@@ -48,36 +48,27 @@ class TaskForm(BaseForm):
         render_kw={"placeholder": "Task description", "rows": 4},
     )
 
-    task_type = StringField(
+    task_type = SelectField(
         "Task Type",
         validators=[DataRequired()],
-        render_kw={
-            "data-search-type": "task_type",
-            "placeholder": "Search task types...",
-            "autocomplete": "off",
-        },
+        choices=[],  # Will be populated in __init__
+        render_kw={"class": "form-select"},
     )
 
-    status = StringField(
+    status = SelectField(
         "Status",
         validators=[DataRequired()],
-        render_kw={
-            "data-search-type": "task_status",
-            "placeholder": "Search status...",
-            "autocomplete": "off",
-            "data-default": "pending",
-        },
+        choices=[],  # Will be populated in __init__
+        default="todo",
+        render_kw={"class": "form-select"},
     )
 
-    priority = StringField(
+    priority = SelectField(
         "Priority",
         validators=[DataRequired()],
-        render_kw={
-            "data-search-type": "task_priority",
-            "placeholder": "Search priority...",
-            "autocomplete": "off",
-            "data-default": "medium",
-        },
+        choices=[],  # Will be populated in __init__
+        default="medium",
+        render_kw={"class": "form-select"},
     )
 
     due_date = DateField("Due Date", validators=[OptionalValidator()])
@@ -128,6 +119,31 @@ class TaskForm(BaseForm):
         from app.models.task import Task
         from app.models.company import Company
         from app.models.opportunity import Opportunity
+        from app.services import MetadataService
+
+        # Get Task field metadata for choices
+        metadata = MetadataService.get_field_metadata(Task)
+
+        # Populate task_type choices
+        if "task_type" in metadata and metadata["task_type"].get("choices"):
+            self.task_type.choices = [
+                (key, data["label"])
+                for key, data in metadata["task_type"]["choices"].items()
+            ]
+
+        # Populate status choices
+        if "status" in metadata and metadata["status"].get("choices"):
+            self.status.choices = [
+                (key, data["label"])
+                for key, data in metadata["status"]["choices"].items()
+            ]
+
+        # Populate priority choices
+        if "priority" in metadata and metadata["priority"].get("choices"):
+            self.priority.choices = [
+                (key, data["label"])
+                for key, data in metadata["priority"]["choices"].items()
+            ]
 
         # Populate company choices
         companies = Company.query.order_by(Company.name).all()

--- a/app/services/query_service.py
+++ b/app/services/query_service.py
@@ -14,6 +14,7 @@ class QueryService:
         Args:
             model: SQLAlchemy model class.
             filters: Dictionary of field:value filters.
+                     Values can be single values or lists for multi-select.
 
         Returns:
             Filtered SQLAlchemy query.
@@ -22,7 +23,18 @@ class QueryService:
 
         for field, value in filters.items():
             if value and hasattr(model, field):
-                query = query.filter(getattr(model, field) == value)
+                # Handle multi-select: convert comma-separated string to list
+                if isinstance(value, str) and "," in value:
+                    values = [v.strip() for v in value.split(",") if v.strip()]
+                    if values:
+                        query = query.filter(getattr(model, field).in_(values))
+                elif isinstance(value, list):
+                    # Handle list directly
+                    if value:
+                        query = query.filter(getattr(model, field).in_(value))
+                else:
+                    # Single value
+                    query = query.filter(getattr(model, field) == value)
 
         return query
 

--- a/app/templates/macros/components.html
+++ b/app/templates/macros/components.html
@@ -266,16 +266,19 @@
                             <div class="relative" x-data="{ open: false, selected: {{ (config.current_value.split(',') if config.current_value else [])|tojson }} }">
                                 <button type="button"
                                         @click="open = !open"
-                                        class="dropdown-select block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-left">
+                                        class="dropdown-select block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-left flex items-center justify-between">
                                     <span x-show="selected.length === 0">{{ config.placeholder or 'Select...' }}</span>
                                     <span x-show="selected.length > 0" x-text="selected.length + ' selected'"></span>
+                                    <span class="ml-2 pointer-events-none">
+                                        {{ icon('chevron-down') }}
+                                    </span>
                                 </button>
                                 <div x-show="open"
                                      @click.away="open = false"
                                      class="absolute z-10 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
                                     {% for option in config.options %}
                                         {% if option.value %}
-                                        <label class="flex items-center px-3 py-2 hover:bg-gray-100 cursor-pointer">
+                                        <label class="flex items-center px-3 py-2 hover:bg-gray-100">
                                             <input type="checkbox"
                                                    value="{{ option.value }}"
                                                    x-model="selected"

--- a/app/templates/macros/components.html
+++ b/app/templates/macros/components.html
@@ -263,10 +263,17 @@
                     {% else %}
                         {# Use regular select for non-searchable #}
                         <select name="{{ config.name or dropdown_key }}"
-                                class="dropdown-select block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                class="dropdown-select block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                {% if config.multiple %}multiple size="4"{% endif %}>
                             {% for option in config.options %}
                                 <option value="{{ option.value }}"
-                                        {% if option.value == config.current_value %}selected{% endif %}>
+                                        {% if config.multiple %}
+                                            {# For multi-select, check if value is in current values #}
+                                            {% if config.current_value and option.value in config.current_value.split(',') %}selected{% endif %}
+                                        {% else %}
+                                            {# Single select #}
+                                            {% if option.value == config.current_value %}selected{% endif %}
+                                        {% endif %}>
                                     {{ option.label }}
                                 </option>
                             {% endfor %}

--- a/app/templates/macros/components.html
+++ b/app/templates/macros/components.html
@@ -261,23 +261,45 @@
                             entity_type=entity_type
                         ) }}
                     {% else %}
-                        {# Use regular select for non-searchable #}
-                        <select name="{{ config.name or dropdown_key }}"
-                                class="dropdown-select block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                                {% if config.multiple %}multiple size="4"{% endif %}>
-                            {% for option in config.options %}
-                                <option value="{{ option.value }}"
-                                        {% if config.multiple %}
-                                            {# For multi-select, check if value is in current values #}
-                                            {% if config.current_value and option.value in config.current_value.split(',') %}selected{% endif %}
-                                        {% else %}
-                                            {# Single select #}
-                                            {% if option.value == config.current_value %}selected{% endif %}
-                                        {% endif %}>
-                                    {{ option.label }}
-                                </option>
-                            {% endfor %}
-                        </select>
+                        {% if config.multiple %}
+                            {# Multi-select checkbox dropdown #}
+                            <div class="relative" x-data="{ open: false, selected: {{ (config.current_value.split(',') if config.current_value else [])|tojson }} }">
+                                <button type="button"
+                                        @click="open = !open"
+                                        class="dropdown-select block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-left">
+                                    <span x-show="selected.length === 0">{{ config.placeholder or 'Select...' }}</span>
+                                    <span x-show="selected.length > 0" x-text="selected.length + ' selected'"></span>
+                                </button>
+                                <div x-show="open"
+                                     @click.away="open = false"
+                                     class="absolute z-10 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+                                    {% for option in config.options %}
+                                        {% if option.value %}
+                                        <label class="flex items-center px-3 py-2 hover:bg-gray-100 cursor-pointer">
+                                            <input type="checkbox"
+                                                   value="{{ option.value }}"
+                                                   x-model="selected"
+                                                   class="mr-2">
+                                            <span>{{ option.label }}</span>
+                                        </label>
+                                        {% endif %}
+                                    {% endfor %}
+                                </div>
+                                <input type="hidden" name="{{ config.name or dropdown_key }}" :value="selected.join(',')">
+                            </div>
+                        {% else %}
+                            {# Regular single-select dropdown #}
+                            <select name="{{ config.name or dropdown_key }}"
+                                    class="dropdown-select block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                    autocomplete="off">
+                                {% for option in config.options %}
+                                    <option value="{{ option.value }}"
+                                            {% if option.value == config.current_value %}selected{% endif %}>
+                                        {{ option.label }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        {% endif %}
                     {% endif %}
                 </div>
             {% endif %}


### PR DESCRIPTION
## Summary
- Converted all entity page filter dropdowns to multi-select checkbox dropdowns
- Converted Group By and Sort By from search inputs to standard dropdowns
- Converted Task form fields (Priority, Status, Task Type) to regular SelectField dropdowns
- Added MEDDPICC Roles as SelectMultipleField

## Changes

### Entity Page Dropdowns
- **Filter dropdowns** (Industry, Company Size, Priority, Status, etc.) now render as multi-select checkbox dropdowns using Alpine.js
- **Group By, Sort By, Order** converted to standard single-select dropdowns (removed search functionality)
- Backend QueryService updated to handle multi-value filtering with SQLAlchemy's `in_()` operator

### Task Form Fields
- Converted Task Type, Priority, and Status from StringField with search to regular SelectField
- Choices populated from Task model metadata via MetadataService
- Applied to both task_forms.py and entities/task.py

### UI Improvements
- Added chevron-down icon to multi-select dropdowns
- Fixed background color consistency (bg-white)
- Fixed cursor styling to match native select elements
- Multi-select dropdowns now visually match single-select dropdowns

### Technical Approach
- Used DRY principles with single boolean flag (`searchable` and `multiple`) controlling dropdown types
- Leveraged existing metadata service and patterns
- No duplicate systems created

## Test Plan
- [x] Test multi-select filtering works on entity pages
- [x] Test Group By and Sort By render as standard dropdowns
- [x] Test Task form dropdowns work correctly
- [x] Verify styling consistency between dropdown types