### PR TITLE
Replace Edit Task form fields with static dropdowns

### DIFF
--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -467,9 +467,9 @@
         {# Handle inline group: task_type, priority, status with proper structure #}
         {% elif field_name == 'task_type' %}
             <div class="form-fields-inline-container">
-                {{ render_dynamic_search_field(form.task_type, 'form-field-inline-item') }}
-                {{ render_dynamic_search_field(form.priority, 'form-field-inline-item') }}
-                {{ render_dynamic_search_field(form.status, 'form-field-inline-item') }}
+                {{ render_field(form.task_type) }}
+                {{ render_field(form.priority) }}
+                {{ render_field(form.status) }}
             </div>
         {% elif field_name == 'priority' or field_name == 'status' %}
             {# Skip - already rendered in inline group #}


### PR DESCRIPTION
## Summary
- Convert task_type, priority, and status fields from dynamic search dropdowns to standard HTML select elements
- Maintains existing three-column grid layout and form-select CSS styling  
- Improves UX by providing simple dropdown selection for these predefined choice fields

## Test plan
- [ ] Open Edit Task modal
- [ ] Verify Task Type, Priority, and Status fields display as normal dropdowns
- [ ] Confirm dropdowns maintain proper spacing in the three-column layout
- [ ] Test that form submission works correctly with the static dropdowns