### PR TITLE
Add team member metrics to User cards

### DIFF
--- a/app/templates/macros/entities.html
+++ b/app/templates/macros/entities.html
@@ -125,8 +125,12 @@
                     {{ meta_icon('trending-up', 'Pipeline Value', meta.pipeline_value) }}
                 {% endif %}
 
-                {% if meta.team_size %}
-                    {{ meta_icon('users', 'Team Size', meta.team_size) }}
+                {% if meta.stakeholders %}
+                    {{ meta_icon('users', 'Stakeholders', meta.stakeholders) }}
+                {% endif %}
+
+                {% if meta.account_team %}
+                    {{ meta_icon('briefcase', 'Account Team', meta.account_team) }}
                 {% endif %}
 
                 {% if meta.active_opportunities %}
@@ -162,6 +166,22 @@
                     {% elif meta.task_type_display == "subtask" %}
                         {{ meta_icon('bars-3', 'Subtask') }}
                     {% endif %}
+                {% endif %}
+
+                {% if meta.assigned_companies %}
+                    {{ meta_icon('building-office', 'Companies', meta.assigned_companies) }}
+                {% endif %}
+
+                {% if meta.assigned_opportunities %}
+                    {{ meta_icon('briefcase', 'Opportunities', meta.assigned_opportunities) }}
+                {% endif %}
+
+                {% if meta.total_pipeline %}
+                    {{ meta_icon('currency-dollar', 'Total Pipeline', meta.total_pipeline) }}
+                {% endif %}
+
+                {% if meta.stakeholder_relationships %}
+                    {{ meta_icon('users', 'Stakeholder Relationships', meta.stakeholder_relationships) }}
                 {% endif %}
 
                 {% if meta.next_step %}

--- a/app/templates/macros/ui.html
+++ b/app/templates/macros/ui.html
@@ -40,7 +40,9 @@
         'exclamation-circle': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/>',
         'list-bullet': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 17.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"/>',
         'bars-3': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/>',
-        'minus': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.5 12h-15"/>'
+        'minus': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.5 12h-15"/>',
+        'building-office': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/>',
+        'briefcase': '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 00.75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 00-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0112 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 01-.673-.38m0 0A2.18 2.18 0 013 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 013.413-.387m7.5 0V5.25A2.25 2.25 0 0013.5 3h-3a2.25 2.25 0 00-2.25 2.25v.894m7.5 0a48.667 48.667 0 00-7.5 0M12 12.75h.008v.008H12v-.008z"/>'
     } -%}
     {%- set size_class = 'w-' + size + ' h-' + size -%}
     {%- if name in icons -%}


### PR DESCRIPTION
## Summary
- Added comprehensive metrics to User/Team Member cards on the dashboard
- Displays key relationship and performance indicators for each team member

## Changes
- **Companies Count**: Shows number of companies assigned to each team member with building icon
- **Opportunities Count**: Shows number of opportunities assigned with briefcase icon  
- **Total Pipeline Value**: Displays aggregate value of all active opportunities (e.g., $650K)
- **Stakeholder Relationships**: Shows count of unique stakeholders the user is working with

## Technical Details
- Added `building-office` and `briefcase` SVG icons to the UI macros
- Extended `get_model_meta_data()` in `model_utils.py` to calculate user-specific metrics
- Updated entity card template to display new metadata fields with appropriate icons
- Metrics only display when values exist (conditional rendering)

## Test Plan
- [x] Verified icons render correctly on dashboard
- [x] Confirmed counts are accurate for test data
- [x] Tested with users having different assignment levels
- [x] Verified pipeline calculations exclude closed opportunities