### PR TITLE
feat: Add draggable modal functionality using Interact.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,28 @@
 # CRM Application - Claude Code Instructions
 
+## 🚨 CRITICAL: FILE LOCATION VERIFICATION
+
+**ALWAYS VERIFY FILE PATHS BEFORE CREATING FILES**
+
+### Static File Location Rules:
+1. **JavaScript files:** `/app/static/js/` NOT `/static/js/`
+2. **CSS files:** `/app/static/css/` NOT `/static/css/`
+3. **Always check existing patterns:** `ls -la app/static/`
+4. **Test in browser:** Open developer console to verify files load without 404 errors
+
+### Before Creating ANY Static File:
+```bash
+# MANDATORY: Check the correct path structure
+ls -la app/static/
+ls -la app/static/js/
+ls -la app/static/css/
+
+# Find similar files to understand the pattern
+find . -name "*.js" -path "*/static/*" | head -5
+```
+
+**BLOCKING: Files in wrong locations will cause 404 errors**
+
 ## 🚨 CRITICAL: MANDATORY DUPLICATE DETECTION BEFORE ANY IMPLEMENTATION
 
 **YOU MUST CHECK FOR DUPLICATES BEFORE WRITING ANY CODE**

--- a/app/static/js/features/modal-draggable.js
+++ b/app/static/js/features/modal-draggable.js
@@ -1,0 +1,179 @@
+/**
+ * Modal Draggable Module
+ * Makes modals draggable using Interact.js
+ * DRY implementation that works with all modal types
+ */
+
+(function() {
+    'use strict';
+
+    const ModalDraggable = {
+        initialized: false,
+        activeModals: new Map(),
+
+        init() {
+            if (this.initialized || typeof interact === 'undefined') return;
+
+            this.setupDraggableModals();
+            this.observeModalChanges();
+            this.initialized = true;
+        },
+
+        setupDraggableModals() {
+            interact('.modal-content')
+                .draggable({
+                    allowFrom: '.modal-header',
+                    inertia: true,
+                    modifiers: [
+                        interact.modifiers.restrictRect({
+                            restriction: 'parent',
+                            endOnly: true
+                        })
+                    ],
+                    autoScroll: false,
+                    listeners: {
+                        start: this.onDragStart.bind(this),
+                        move: this.onDragMove.bind(this),
+                        end: this.onDragEnd.bind(this)
+                    }
+                })
+                .styleCursor(false);
+        },
+
+        onDragStart(event) {
+            const modal = event.target;
+            const modalId = this.getModalId(modal);
+
+            modal.classList.add('is-dragging');
+            modal.style.cursor = 'grabbing';
+
+            if (!this.activeModals.has(modalId)) {
+                this.activeModals.set(modalId, { x: 0, y: 0 });
+            }
+        },
+
+        onDragMove(event) {
+            const modal = event.target;
+            const modalId = this.getModalId(modal);
+            const position = this.activeModals.get(modalId);
+
+            if (position) {
+                position.x += event.dx;
+                position.y += event.dy;
+
+                this.updateModalPosition(modal, position);
+            }
+        },
+
+        onDragEnd(event) {
+            const modal = event.target;
+            modal.classList.remove('is-dragging');
+            modal.style.cursor = '';
+        },
+
+        updateModalPosition(modal, position) {
+            modal.style.transform = `translate(${position.x}px, ${position.y}px)`;
+        },
+
+        resetModalPosition(modal) {
+            const modalId = this.getModalId(modal);
+
+            modal.style.transform = '';
+            modal.style.cursor = '';
+            modal.classList.remove('is-dragging');
+
+            if (this.activeModals.has(modalId)) {
+                this.activeModals.delete(modalId);
+            }
+        },
+
+        getModalId(modalElement) {
+            const parentModal = modalElement.closest('.modal');
+            return parentModal ? parentModal.id || 'default-modal' : 'default-modal';
+        },
+
+        observeModalChanges() {
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    mutation.removedNodes.forEach((node) => {
+                        if (node.nodeType === 1 && node.classList?.contains('modal')) {
+                            const modalContent = node.querySelector('.modal-content');
+                            if (modalContent) {
+                                this.resetModalPosition(modalContent);
+                            }
+                        }
+                    });
+
+                    mutation.addedNodes.forEach((node) => {
+                        if (node.nodeType === 1 && node.classList?.contains('modal')) {
+                            const modalContent = node.querySelector('.modal-content');
+                            if (modalContent) {
+                                this.resetModalPosition(modalContent);
+                            }
+                        }
+                    });
+                });
+            });
+
+            observer.observe(document.body, {
+                childList: true,
+                subtree: true
+            });
+        },
+
+        addModalStyles() {
+            if (document.getElementById('modal-draggable-styles')) return;
+
+            const styles = document.createElement('style');
+            styles.id = 'modal-draggable-styles';
+            styles.textContent = `
+                .modal-header {
+                    cursor: grab;
+                    user-select: none;
+                }
+
+                .modal-header:active,
+                .modal-content.is-dragging .modal-header {
+                    cursor: grabbing;
+                }
+
+                .modal-content {
+                    transition: none;
+                }
+
+                .modal-content.is-dragging {
+                    opacity: 0.95;
+                    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.35);
+                }
+            `;
+
+            document.head.appendChild(styles);
+        }
+    };
+
+    function initModalDraggable() {
+        ModalDraggable.addModalStyles();
+        ModalDraggable.init();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initModalDraggable);
+    } else {
+        initModalDraggable();
+    }
+
+    window.ModalDraggable = ModalDraggable;
+
+    document.addEventListener('htmx:afterSwap', function(event) {
+        if (event.detail.target.classList?.contains('modal') ||
+            event.detail.target.querySelector?.('.modal')) {
+            setTimeout(() => ModalDraggable.init(), 100);
+        }
+    });
+
+    if (window.Alpine) {
+        document.addEventListener('alpine:initialized', () => {
+            ModalDraggable.init();
+        });
+    }
+})();

--- a/app/templates/base/includes/head.html
+++ b/app/templates/base/includes/head.html
@@ -49,6 +49,9 @@
 {# Core JavaScript Libraries #}
 <script src="https://unpkg.com/htmx.org@2.0.3/dist/htmx.min.js"></script>
 
+{# Interact.js for draggable modals #}
+<script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+
 {# Alpine.js - Load first #}
 <script defer src="https://unpkg.com/alpinejs@3.14.3/dist/cdn.min.js"></script>
 
@@ -202,3 +205,4 @@ window.dropdown = function(config = {}) {
 <script src="{{ url_for('static', filename='js/features/search-widget.js') }}"></script>
 <script src="{{ url_for('static', filename='js/features/form-enhancements.js') }}"></script>
 <script src="{{ url_for('static', filename='js/core/modal-handlers.js') }}"></script>
+<script src="{{ url_for('static', filename='js/features/modal-draggable.js') }}"></script>

--- a/app/templates/components/modals/delete_modal.html
+++ b/app/templates/components/modals/delete_modal.html
@@ -7,7 +7,12 @@ Simple confirmation dialog following existing modal patterns
 <div class="modal"
      x-data="{
          open: true,
+         dragPosition: { x: 0, y: 0 },
          close() {
+             if (window.ModalDraggable) {
+                 const modalContent = document.querySelector('#{{ model_name }}-delete-modal .modal-content');
+                 if (modalContent) window.ModalDraggable.resetModalPosition(modalContent);
+             }
              htmx.ajax('GET', '/modals/close', {target: '#modal-container', swap: 'innerHTML'});
          }
      }"

--- a/app/templates/components/modals/form_success.html
+++ b/app/templates/components/modals/form_success.html
@@ -7,7 +7,12 @@ Shows success and auto-closes or allows manual close
 <div class="modal"
      x-data="{
          open: true,
+         dragPosition: { x: 0, y: 0 },
          close() {
+             if (window.ModalDraggable) {
+                 const modalContent = document.querySelector('#success-modal .modal-content');
+                 if (modalContent) window.ModalDraggable.resetModalPosition(modalContent);
+             }
              this.open = false;
              // Close the modal
              htmx.ajax('GET', '/modals/close', {target: '#modal-container', swap: 'innerHTML'});

--- a/app/templates/components/modals/wtforms_modal.html
+++ b/app/templates/components/modals/wtforms_modal.html
@@ -26,6 +26,7 @@ if (typeof selectEntity === 'undefined') {
          validationTimer: null,
          isValidating: false,
          taskCategory: 'opportunity',
+         dragPosition: { x: 0, y: 0 },
          updateTaskFields(category) {
              this.taskCategory = category;
          },
@@ -96,6 +97,10 @@ if (typeof selectEntity === 'undefined') {
              return true;
          },
          close() {
+             if (window.ModalDraggable) {
+                 const modalContent = document.querySelector('#{{ model_name }}-modal .modal-content');
+                 if (modalContent) window.ModalDraggable.resetModalPosition(modalContent);
+             }
              htmx.ajax('GET', '/modals/close', {target: '#{{ model_name }}-modal', swap: 'outerHTML'});
          }
      }"

--- a/static/js/core/modal-handlers.js
+++ b/static/js/core/modal-handlers.js
@@ -11,6 +11,7 @@ function modal(config = {}) {
         type: config.type || 'info',
         autoShow: config.autoShow !== false,
         open: false,
+        dragPosition: { x: 0, y: 0 },
 
         init() {
             // Auto-show modal on initialization if configured
@@ -27,6 +28,12 @@ function modal(config = {}) {
         },
 
         hide() {
+            // Reset position if modal was dragged
+            if (window.ModalDraggable) {
+                const modalContent = document.querySelector(`#${this.id} .modal-content`);
+                if (modalContent) window.ModalDraggable.resetModalPosition(modalContent);
+            }
+
             this.open = false;
             document.body.style.overflow = '';
 


### PR DESCRIPTION
## Summary
- Implemented DRY modal dragging solution using Interact.js library
- All modals can now be dragged by their header/title bar
- Position automatically resets when modals close

## Changes
- Added Interact.js CDN to the project
- Created `modal-draggable.js` module for centralized drag handling
- Updated modal templates to include drag position tracking
- Enhanced modal close handlers to reset position
- Added file location verification rules to CLAUDE.md to prevent future path errors

## Test Plan
- [x] Open any modal (Company, User, Task, etc.)
- [x] Click and drag the modal by its header
- [x] Verify cursor changes to grab/grabbing
- [x] Close modal and verify position resets
- [x] Test with multiple modal types