### PR TITLE
Fix Task form search fields to use existing DRY patterns

### DIFF
--- a/app/forms/tasks/task_forms.py
+++ b/app/forms/tasks/task_forms.py
@@ -78,16 +78,27 @@ class TaskForm(BaseForm):
         "Assigned To",
         validators=[OptionalValidator()],
         render_kw={
-            "data-search-type": "assignment",
-            "placeholder": "Search assignees...",
+            "placeholder": "Search team members...",
             "autocomplete": "off",
         },
     )
 
-    company_id = SelectField("Company", coerce=int, validators=[OptionalValidator()])
+    company_id = StringField(
+        "Company",
+        validators=[OptionalValidator()],
+        render_kw={
+            "placeholder": "Search companies...",
+            "autocomplete": "off",
+        },
+    )
 
-    opportunity_id = SelectField(
-        "Opportunity", coerce=int, validators=[OptionalValidator()]
+    opportunity_id = StringField(
+        "Opportunity",
+        validators=[OptionalValidator()],
+        render_kw={
+            "placeholder": "Search opportunities...",
+            "autocomplete": "off",
+        },
     )
 
     next_step_type = SelectField(
@@ -117,8 +128,6 @@ class TaskForm(BaseForm):
         super().__init__(*args, **kwargs)
         # Populate choices from model
         from app.models.task import Task
-        from app.models.company import Company
-        from app.models.opportunity import Opportunity
         from app.services import MetadataService
 
         # Get Task field metadata for choices
@@ -145,18 +154,6 @@ class TaskForm(BaseForm):
                 for key, data in metadata["priority"]["choices"].items()
             ]
 
-        # Populate company choices
-        companies = Company.query.order_by(Company.name).all()
-        self.company_id.choices = [(0, "No Company")] + [
-            (c.id, c.name) for c in companies
-        ]
-
-        # Populate opportunity choices
-        opportunities = Opportunity.query.order_by(Opportunity.name).all()
-        self.opportunity_id.choices = [(0, "No Opportunity")] + [
-            (o.id, o.name) for o in opportunities
-        ]
-
         # Populate remaining SelectField choices
         self.next_step_type.choices = [
             ("", "Select next step type")
@@ -167,9 +164,7 @@ class TaskForm(BaseForm):
 
     def validate_company_id(self, field):
         """Validate that Company is required for Opportunity tasks."""
-        if self.task_category.data == "opportunity" and (
-            not field.data or field.data == 0
-        ):
+        if self.task_category.data == "opportunity" and not field.data:
             raise ValidationError("Company is required for Opportunity tasks.")
 
     def get_display_fields(self):

--- a/app/templates/macros/forms.html
+++ b/app/templates/macros/forms.html
@@ -421,7 +421,7 @@
 {# ============================================
    DYNAMIC SEARCH FIELD RENDERING
    ============================================ #}
-{% macro render_dynamic_search_field(field, additional_classes='') %}
+{% macro render_dynamic_search_field(field, additional_classes='', entity_type='') %}
     <div class="form-field-group {{ additional_classes }}">
         <label for="{{ field.id }}" class="form-label{% if field.flags.required %} form-label-required{% endif %}">
             {{ field.label.text }}
@@ -430,18 +430,18 @@
             <input type="text"
                    id="{{ field.id }}_search"
                    name="q"
-                   class="form-input w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                   class="search-input form-input w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                    placeholder="{{ field.render_kw.placeholder if field.render_kw and field.render_kw.placeholder else 'Search...' }}"
                    autocomplete="off"
                    hx-get="{{ url_for('search.htmx_search') }}"
                    hx-trigger="input changed delay:300ms, focus"
-                   hx-target="#{{ field.id }}_results"
+                   hx-target="#{{ field.id }}_search-results"
                    hx-swap="innerHTML"
-                   hx-vals='{"mode": "select", "type": "{{ field.render_kw.get('data-search-type', 'task_field') if field.render_kw else 'task_field' }}", "field_name": "{{ field.name }}"}'>
+                   hx-vals='{"mode": "select", "type": "{{ entity_type or field.render_kw.get('data-search-type', 'task_field') if field.render_kw else 'task_field' }}", "field_name": "{{ field.name }}"}'>
             <input type="hidden" name="{{ field.name }}" id="{{ field.id }}" value="{{ field.data or '' }}">
-            <div id="{{ field.id }}_results"
-                 class="absolute top-full mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-y-auto"
-                 hidden></div>
+            <div id="{{ field.id }}_search-results"
+                 class="absolute top-full mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-y-auto hidden"
+                 ></div>
         </div>
         {% if field.errors %}
             {% for error in field.errors %}
@@ -462,8 +462,8 @@
         {% if field_name == 'company_id' %}
             <div x-show="taskCategory === 'opportunity'" class="conditional-field">
                 <div class="grid grid-cols-2 gap-4">
-                    {{ render_dynamic_search_field(field) }}
-                    {{ render_dynamic_search_field(form.opportunity_id) }}
+                    {{ render_dynamic_search_field(field, entity_type='company') }}
+                    {{ render_dynamic_search_field(form.opportunity_id, entity_type='opportunity') }}
                 </div>
             </div>
         {% elif field_name == 'opportunity_id' %}
@@ -490,7 +490,7 @@
         {% elif field_name == 'due_date' %}
             {# Skip - already rendered with name #}
         {% elif field_name == 'assigned_to_id' %}
-            {{ render_dynamic_search_field(field) }}
+            {{ render_dynamic_search_field(field, entity_type='user') }}
         {% else %}
             {{ render_field(field) }}
         {% endif %}


### PR DESCRIPTION
## Summary
- Fixed Company and Opportunity fields in Create Task form to provide search suggestions
- Used existing DRY patterns instead of creating new code

## Changes
- Enhanced `render_dynamic_search_field` macro with `search-input` class for JS initialization
- Changed Task form fields from SelectField to StringField (consistent with Company form)
- Pass correct entity types to search endpoint
- Removed performance issue of loading all companies/opportunities upfront

## Result
Task form now provides dynamic search exactly like global search and Add Company forms, using the same existing patterns.