### PR TITLE
fix: Remove hx-trigger="click once" from company view modal tabs

### DIFF
--- a/app/templates/components/modals/wtforms_modal.html
+++ b/app/templates/components/modals/wtforms_modal.html
@@ -139,8 +139,7 @@ if (typeof selectEntity === 'undefined') {
                                     @click="activeTab = 'about'"
                                     hx-get="/modals/{{ model_name }}/{{ entity_id }}/tab/about"
                                     hx-target="#modal-tab-content"
-                                    hx-swap="innerHTML"
-                                    hx-trigger="click once">
+                                    hx-swap="innerHTML">
                                 About
                             </button>
                             <button class="modal-nav-item"
@@ -148,8 +147,7 @@ if (typeof selectEntity === 'undefined') {
                                     @click="activeTab = 'team'"
                                     hx-get="/modals/{{ model_name }}/{{ entity_id }}/tab/team"
                                     hx-target="#modal-tab-content"
-                                    hx-swap="innerHTML"
-                                    hx-trigger="click once">
+                                    hx-swap="innerHTML">
                                 Account Team
                             </button>
                             <button class="modal-nav-item"
@@ -157,8 +155,7 @@ if (typeof selectEntity === 'undefined') {
                                     @click="activeTab = 'opportunities'"
                                     hx-get="/modals/{{ model_name }}/{{ entity_id }}/tab/opportunities"
                                     hx-target="#modal-tab-content"
-                                    hx-swap="innerHTML"
-                                    hx-trigger="click once">
+                                    hx-swap="innerHTML">
                                 Opportunities
                             </button>
                             <button class="modal-nav-item"
@@ -166,8 +163,7 @@ if (typeof selectEntity === 'undefined') {
                                     @click="activeTab = 'stakeholders'"
                                     hx-get="/modals/{{ model_name }}/{{ entity_id }}/tab/stakeholders"
                                     hx-target="#modal-tab-content"
-                                    hx-swap="innerHTML"
-                                    hx-trigger="click once">
+                                    hx-swap="innerHTML">
                                 Stakeholders
                             </button>
                         </div>


### PR DESCRIPTION
## Summary
- Fixed tab navigation issue in View Company modal where tabs stopped responding after first click
- Removed `hx-trigger="click once"` from all four tab buttons (About, Account Team, Opportunities, Stakeholders)
- Tabs now use default click behavior and work properly for multiple clicks

## Problem
Users reported that after clicking tabs in the View Company modal (e.g., Opportunities → Account Team → Opportunities), the second click on Opportunities would not work. The tab would appear active but content wouldn't load.

## Root Cause
The `hx-trigger="click once"` attribute meant HTMX would only handle the first click event on each tab button, preventing subsequent clicks from triggering HTMX requests.

## Solution
Removed the `hx-trigger="click once"` attribute from all tab buttons, allowing HTMX to handle every click normally.

## Test Plan
- [x] Open View Company modal
- [x] Click Opportunities tab (works)
- [x] Click Account Team tab (works) 
- [x] Click Opportunities tab again (now works - was broken before)
- [x] Verify all tabs can be clicked multiple times
- [x] Confirm content loads correctly each time