### PR TITLE
Add dynamic modal headings with entity names

### DIFF
--- a/app/routes/web/modals.py
+++ b/app/routes/web/modals.py
@@ -106,7 +106,11 @@ def render_modal(model_name, form, mode="create", entity=None):
         "model_name": model_name,
         "model_class": MODEL_REGISTRY.get(model_name.lower()),
         "form": form,
-        "modal_title": f"{mode.title()} {model_name.title()}",
+        "modal_title": (
+            f"{'Viewing' if mode == 'view' else 'Editing'}: {entity.name}"
+            if entity and hasattr(entity, 'name') and entity.name and mode in ['view', 'edit']
+            else f"{mode.title()} {model_name.title()}"
+        ),
         "mode": mode,
         "is_view": mode == "view",
         "is_edit": mode == "edit",


### PR DESCRIPTION
## Summary
- Changes modal titles from generic "View Company" to specific "Viewing: Company Name"
- Changes "Edit Company" to "Editing: Company Name" 
- Creates more contextual user experience by showing exactly which entity is being viewed or edited

## Implementation
- Single DRY modification to `render_modal()` function in `app/routes/web/modals.py`
- Uses format "Viewing: {entity.name}" for view mode
- Uses format "Editing: {entity.name}" for edit mode  
- Maintains backward compatibility with "Create {EntityType}" for create mode
- Works universally across all entity types (companies, stakeholders, opportunities, etc.)

## Test plan
- [x] Test company viewing modal shows "Viewing: ConsultPro Services"
- [x] Test company editing modal shows "Editing: ConsultPro Services"
- [x] Test stakeholder viewing modal shows "Viewing: Thomas Anderson"
- [x] Test create modals still show generic titles like "Create Company"
- [x] Verify works across different entity types
- [x] Confirm proper fallback behavior when entity has no name