### PR TITLE
Implement comprehensive DRY currency and number formatting

### DIFF
--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -134,8 +134,19 @@ class SearchService:
         if isinstance(value, (date, datetime)):
             return value.strftime("%d/%m/%y")
 
+        # Handle currency fields (any field containing 'value', 'price', 'cost', 'amount')
+        if (isinstance(value, (int, float)) and
+            any(currency_term in field_name.lower() for currency_term in ['value', 'price', 'cost', 'amount', 'pipeline'])):
+            from app.utils.formatters import format_currency_short
+            return format_currency_short(value)
+
+        # Handle large numbers that might need comma formatting
+        elif isinstance(value, (int, float)) and value >= 1000:
+            from app.utils.formatters import format_number
+            return format_number(value)
+
         # Handle status/stage/priority fields
-        if field_name in {"status", "stage", "priority"}:
+        elif field_name in {"status", "stage", "priority"}:
             return str(value).replace("_", " ").title()
 
         # Default string conversion

--- a/app/templates/components/modals/tabs/company_opportunities.html
+++ b/app/templates/components/modals/tabs/company_opportunities.html
@@ -53,15 +53,7 @@ console.groupEnd();
                                 <span class="flex items-center gap-1">
                                     {{ icon('currency-dollar', size='4', class='text-gray-400') }}
                                     <span class="font-medium">
-                                        {% if opportunity.value is none or opportunity.value == 0 %}
-                                            $0
-                                        {% elif opportunity.value and opportunity.value >= 1000000 %}
-                                            ${{ (opportunity.value / 1000000)|round(1) }}M
-                                        {% elif opportunity.value and opportunity.value >= 1000 %}
-                                            ${{ (opportunity.value / 1000)|round(0)|int }}K
-                                        {% else %}
-                                            ${{ opportunity.value }}
-                                        {% endif %}
+                                        {{ opportunity.value|format_currency_short }}
                                     </span>
                                 </span>
                                 <span class="flex items-center gap-1">
@@ -91,8 +83,8 @@ console.groupEnd();
         {% if opportunities.pages > 1 %}
             <div class="modal-pagination">
                 <div class="modal-pagination-info">
-                    Showing {{ opportunities.per_page * (opportunities.page - 1) + 1 }} -
-                    {{ min(opportunities.per_page * opportunities.page, opportunities.total) }} of {{ opportunities.total }}
+                    Showing {{ (opportunities.per_page * (opportunities.page - 1) + 1)|format_number }} -
+                    {{ min(opportunities.per_page * opportunities.page, opportunities.total)|format_number }} of {{ opportunities.total|format_number }}
                 </div>
                 <div class="modal-pagination-controls">
                     {# Previous button #}

--- a/app/templates/components/modals/tabs/company_stakeholders.html
+++ b/app/templates/components/modals/tabs/company_stakeholders.html
@@ -48,8 +48,8 @@
         {% if stakeholders.pages > 1 %}
             <div class="modal-pagination">
                 <div class="modal-pagination-info">
-                    Showing {{ stakeholders.per_page * (stakeholders.page - 1) + 1 }} -
-                    {{ min(stakeholders.per_page * stakeholders.page, stakeholders.total) }} of {{ stakeholders.total }}
+                    Showing {{ (stakeholders.per_page * (stakeholders.page - 1) + 1)|format_number }} -
+                    {{ min(stakeholders.per_page * stakeholders.page, stakeholders.total)|format_number }} of {{ stakeholders.total|format_number }}
                 </div>
                 <div class="modal-pagination-controls">
                     {# Previous button #}

--- a/app/templates/shared/entity_content.html
+++ b/app/templates/shared/entity_content.html
@@ -8,7 +8,7 @@
     {# Show total count #}
     {% if total_count > 0 and grouped_entities|length > 0 %}
         <div class="text-sm text-gray-600 mb-4">
-            Showing {{ total_count }} {{ entity_name_singular if total_count == 1 else entity_name }}
+            Showing {{ total_count|format_number }} {{ entity_name_singular if total_count == 1 else entity_name }}
         </div>
     {% endif %}
 

--- a/app/utils/formatters.py
+++ b/app/utils/formatters.py
@@ -10,12 +10,15 @@ def format_number(value):
     Returns:
         Formatted string with commas (e.g., 75000 → 75,000)
     """
-    if value is None:
+    if value is None or value == "":
         return "0"
     try:
+        # Handle string inputs that might be numeric
+        if isinstance(value, str):
+            value = float(value) if '.' in value else int(value)
         return f"{int(value):,}"
     except (ValueError, TypeError):
-        return str(value)
+        return "0"
 
 
 def format_currency(value):
@@ -27,12 +30,15 @@ def format_currency(value):
     Returns:
         Formatted currency string (e.g., 75000 → $75,000)
     """
-    if value is None:
+    if value is None or value == "" or value == 0:
         return "$0"
     try:
+        # Handle string inputs that might be numeric
+        if isinstance(value, str):
+            value = float(value) if '.' in value else int(value)
         return f"${int(value):,}"
     except (ValueError, TypeError):
-        return f"${value}"
+        return "$0"
 
 
 def format_currency_short(value):
@@ -44,18 +50,26 @@ def format_currency_short(value):
     Returns:
         Formatted currency string (e.g., "$1.5M", "$250K", "$100")
     """
-    if value is None:
+    if value is None or value == "" or value == 0:
         return "$0"
 
     try:
+        # Handle string inputs that might be numeric
+        if isinstance(value, str):
+            value = float(value) if '.' in value else int(value)
+
         value = float(value)
         if value >= 1000000:
-            return f"${value/1000000:.1f}M"
+            # Format millions with 1 decimal if needed, but remove .0
+            formatted = f"{value/1000000:.1f}M"
+            if formatted.endswith('.0M'):
+                formatted = formatted[:-3] + 'M'
+            return f"${formatted}"
         elif value >= 1000:
             return f"${value/1000:.0f}K"
         return f"${int(value):,}"
     except (ValueError, TypeError):
-        return f"${value}"
+        return "$0"
 
 
 def format_percentage(value):

--- a/app/utils/model_utils.py
+++ b/app/utils/model_utils.py
@@ -2,6 +2,7 @@
 
 from typing import List, Dict, Any
 from datetime import date
+from app.utils.formatters import format_currency_short
 
 
 def get_recent_items(model_class, limit: int = 5) -> List:
@@ -83,11 +84,7 @@ def get_model_meta_data(model_instance) -> Dict[str, Any]:
             active_opps = [opp for opp in model_instance.opportunities if opp.stage not in ["closed-won", "closed-lost"]]
             pipeline_value = sum(opp.value or 0 for opp in active_opps)
             if pipeline_value > 0:
-                if pipeline_value >= 1000:
-                    pipeline_display = f"${pipeline_value // 1000}K"
-                else:
-                    pipeline_display = f"${pipeline_value}"
-                meta["pipeline_value"] = pipeline_display
+                meta["pipeline_value"] = format_currency_short(pipeline_value)
 
             # Active opportunities count
             if active_opps:
@@ -134,11 +131,7 @@ def get_model_meta_data(model_instance) -> Dict[str, Any]:
     elif entity_type == "opportunity":
         # Deal size and stage
         if hasattr(model_instance, "value") and model_instance.value:
-            if model_instance.value >= 1000:
-                deal_value = f"${model_instance.value // 1000}K"
-            else:
-                deal_value = f"${model_instance.value}"
-            meta["deal_size"] = deal_value
+            meta["deal_size"] = format_currency_short(model_instance.value)
 
         if hasattr(model_instance, "stage") and model_instance.stage:
             stage_display = model_instance.stage.replace("-", " ").replace("_", " ").title()
@@ -181,13 +174,7 @@ def get_model_meta_data(model_instance) -> Dict[str, Any]:
                     total_pipeline += opp.value
 
             if total_pipeline > 0:
-                if total_pipeline >= 1000000:
-                    pipeline_display = f"${total_pipeline // 1000000}M"
-                elif total_pipeline >= 1000:
-                    pipeline_display = f"${total_pipeline // 1000}K"
-                else:
-                    pipeline_display = f"${total_pipeline}"
-                meta["total_pipeline"] = pipeline_display
+                meta["total_pipeline"] = format_currency_short(total_pipeline)
 
         # Total stakeholder relationships (through opportunities or direct)
         # Count unique stakeholders user is working with


### PR DESCRIPTION
## Summary
Implements comprehensive, DRY currency and number formatting throughout the entire CRM application ensuring all dollar figures have proper $ prefix and comma separators.

## Key Changes
- **Enhanced central formatters** (`app/utils/formatters.py`): Improved edge case handling for null/empty values and string inputs
- **Intelligent search formatting** (`app/services/search_service.py`): Added automatic currency detection for any field containing 'value', 'price', 'cost', 'amount', 'pipeline'
- **Eliminated inline formatting**: Replaced template-embedded currency logic with centralized `format_currency_short` filter
- **Updated Python modules**: Modified `model_utils.py` to use centralized formatters instead of inline string formatting
- **Enhanced templates**: Added number formatting to pagination displays and entity counts

## Problems Solved
- ✅ **Search results**: Fixed "60000 • Negotiation" displaying as raw numbers, now shows "$60K • Negotiation"
- ✅ **Dashboard consistency**: All pipeline values, deal sizes show with proper $ and K/M abbreviations
- ✅ **Modal formatting**: Company opportunity values properly formatted in all modals
- ✅ **Pagination**: All counts use comma separators (1,234 instead of 1234)

## Architecture Benefits
- **Single source of truth**: All formatting handled by `app/utils/formatters.py`
- **Zero duplication**: Eliminated scattered inline formatting logic
- **Future-proof**: Any new currency/value field automatically gets proper formatting
- **Extensible**: DRY approach works for any numeric field names containing currency terms

## Test Plan
- [x] Verify dashboard displays all currency values with $ prefix and K/M abbreviations
- [x] Confirm search results show "$60K • Negotiation" instead of "60000 • Negotiation"  
- [x] Check company modals show properly formatted opportunity values
- [x] Validate pagination displays use comma separators for large numbers
- [x] Test edge cases (null values, empty strings, zero amounts) display as "$0"